### PR TITLE
feat: 연관관계 편의 메서드 개발 및 기본 키 생성 전략 수정

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/Appointment.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/Appointment.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Getter
 public class Appointment {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "appointment_id")
     private Long id;
 
@@ -31,4 +31,33 @@ public class Appointment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hosp_id")
     private Hospital hospital;
+
+    /* 연관관계 편의메서드 */
+    public void setHospital(Hospital hospital) {
+        //comment: 기존 관계 제거
+        if (this.hospital != null) {
+            this.hospital.getAppointmentList().remove(this);
+        }
+
+        this.hospital = hospital;
+
+        //comment: 무한루프 방지
+        if (!hospital.getAppointmentList().contains(this)) {
+            hospital.getAppointmentList().add(this);
+        }
+    }
+
+    public void setMember(Member member) {
+        //comment: 기존 관계 제거
+        if (this.member != null) {
+            this.member.getAppointmentList().remove(this);
+        }
+
+        this.member = member;
+
+        //comment: 무한루프에 빠지지 않도록 체크
+        if (!member.getAppointmentList().contains(this)) {
+            member.getAppointmentList().add(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/Board.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/Board.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Getter
 public class Board {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "board_id")
     private Long id;
 
@@ -40,4 +40,26 @@ public class Board {
 
     @OneToMany(mappedBy = "board")
     private final List<BoardReply> boardReplyList = new ArrayList<>();
+
+    /* 연관관계 편의 메서드 */
+    public void addBoardReply(BoardReply boardReply) {
+        this.boardReplyList.add(boardReply);
+        if (boardReply.getBoard() != this) { //무한루프에 빠지지 않도록 체크
+            boardReply.setBoard(this);
+        }
+    }
+
+    public void setMember(Member member) {
+        //comment: 기존 관계 제거
+        if (this.member != null) {
+            this.member.getBoardList().remove(this);
+        }
+
+        this.member = member;
+
+        //comment: 무한루프 방지
+        if (!member.getBoardList().contains(this)) {
+            member.getBoardList().add(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/BoardReply.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/BoardReply.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class BoardReply {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "board_reply_id")
     private Long id;
 
@@ -25,4 +25,33 @@ public class BoardReply {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "staff_id")
     private Staff staff;
+
+    /* 연관관계 편의메서드 */
+    public void setBoard(Board board) {
+        //comment: 기존 관계 제거
+        if (this.board != null) {
+            this.board.getBoardReplyList().remove(this);
+        }
+
+        this.board = board;
+
+        //comment: 무한루프 방지
+        if (!board.getBoardReplyList().contains(this)) {
+            board.getBoardReplyList().add(this);
+        }
+    }
+
+    public void setStaff(Staff staff) {
+        //comment: 기존 관계 제거
+        if (this.staff != null) {
+            this.staff.getBoardReplyList().remove(this);
+        }
+
+        this.staff = staff;
+
+        //comment: 무한루프에 빠지지 않도록 체크
+        if (!staff.getBoardReplyList().contains(this)) {
+            staff.getBoardReplyList().add(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/BusInfo.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/BusInfo.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class BusInfo {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "bus_info_id")
     private Long id;
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/HealthInfo.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/HealthInfo.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Table(name = "health_info")
 public class HealthInfo {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "health_info_id")
     private Long id;
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/Hospital.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/Hospital.java
@@ -8,10 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @Setter
+@Getter
 public class Hospital {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "hosp_id")
     private Long id;
 
@@ -32,4 +32,32 @@ public class Hospital {
 
     @OneToMany(mappedBy = "hospital")
     private final List<Staff> staffList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private final List<Pick> pickList = new ArrayList<>();
+
+    /* 연관관계 편의 메서드 */
+    public void addAppointment(Appointment appointment) {
+        this.appointmentList.add(appointment);
+
+        if (appointment.getHospital() != this) { //무한루프에 빠지지 않도록 체크
+            appointment.setHospital(this);
+        }
+    }
+
+    public void addPick(Pick pick) {
+        this.pickList.add(pick);
+
+        if (pick.getHospital() != this) { //무한루프에 빠지지 않도록 체크
+            pick.setHospital(this);
+        }
+    }
+
+    public void addStaff(Staff staff) {
+        this.staffList.add(staff);
+
+        if (staff.getHospital() != this) {
+            staff.setHospital(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/Member.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/Member.java
@@ -8,10 +8,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @Setter
+@Getter
 public class Member {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue()
     @Column(name = "member_id")
     private Long id;
 
@@ -32,4 +33,50 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private final List<ReviewReply> reviewReplyList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private final List<Appointment> appointmentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private final List<Pick> pickList = new ArrayList<>();
+
+
+    /* 연관관계 편의 메소드 */
+    public void addAppointment(Appointment appointment) {
+        this.appointmentList.add(appointment);
+        if (appointment.getMember() != this) { //무한루프에 빠지지 않도록 체크
+            appointment.setMember(this);
+        }
+    }
+
+    public void addPick(Pick pick) {
+        this.pickList.add(pick);
+        if (pick.getMember() != this) { //무한루프에 빠지지 않도록 체크
+            pick.setMember(this);
+        }
+    }
+
+    public void addBoard(Board board) {
+        this.boardList.add(board);
+
+        if (board.getMember() != this) {
+            board.setMember(this);
+        }
+    }
+
+    public void addReview(Review review) {
+        this.reviewList.add(review);
+
+        if (review.getMember() != this) {
+            review.setMember(this);
+        }
+    }
+
+    public void addReviewReply(ReviewReply reviewReply) {
+        this.reviewReplyList.add(reviewReply);
+
+        if (reviewReply.getMember() != this) {
+            reviewReply.setMember(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/Pick.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/Pick.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 public class Pick {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "pick_id")
     private Long id;
 
@@ -23,4 +23,32 @@ public class Pick {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hosp_id")
     private Hospital hospital;
+
+    /* 연관관계 편의메서드 */
+    public void setHospital(Hospital hospital) {
+        if (this.hospital != null) {
+            this.hospital.getPickList().remove(this);
+        }
+
+        this.hospital = hospital;
+
+        //comment: 무한루프 방지
+        if (!hospital.getPickList().contains(this)) {
+            hospital.getPickList().add(this);
+        }
+    }
+
+    public void setMember(Member member) {
+        //comment: 기존 관계 제거
+        if (this.member != null) {
+            this.member.getPickList().remove(this);
+        }
+
+        this.member = member;
+
+        //comment: 무한루프에 빠지지 않도록 체크
+        if (!member.getPickList().contains(this)) {
+            member.getPickList().add(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/Review.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/Review.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Getter
 public class Review {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "review_id")
     private Long id;
 
@@ -46,4 +46,27 @@ public class Review {
 
     @OneToMany(mappedBy = "review")
     private List<ReviewReply> reviewReplyList = new ArrayList<>();
+
+    /* 연관관계 편의 메서드 */
+    public void setMember(Member member) {
+        //comment: 기존 관계 제거
+        if (this.member != null) {
+            this.member.getReviewList().remove(this);
+        }
+
+        this.member = member;
+
+        //comment: 무한루프 방지
+        if (!member.getReviewList().contains(this)) {
+            member.getReviewList().add(this);
+        }
+    }
+
+    public void addReviewReply(ReviewReply reviewReply) {
+        this.reviewReplyList.add(reviewReply);
+
+        if (reviewReply.getReview() != this) {
+            reviewReply.setReview(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/ReviewReply.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/ReviewReply.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class ReviewReply {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "review_reply_id")
     private Long id;
 
@@ -25,4 +25,33 @@ public class ReviewReply {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    /* 연관관계 메서드 */
+    public void setMember(Member member) {
+        //comment: 기존 관계 제거
+        if (this.member != null) {
+            this.member.getReviewReplyList().remove(this);
+        }
+
+        this.member = member;
+
+        //comment: 무한루프에 빠지지 않도록 체크
+        if (!member.getReviewReplyList().contains(this)) {
+            member.getReviewReplyList().add(this);
+        }
+    }
+
+    public void setReview(Review review) {
+        //comment: 기존 관계 제거
+        if (this.review != null) {
+            this.review.getReviewReplyList().remove(this);
+        }
+
+        this.review = review;
+
+        //comment: 무한루프에 빠지지 않도록 체크
+        if (!review.getReviewReplyList().contains(this)) {
+            review.getReviewReplyList().add(this);
+        }
+    }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/Staff.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/Staff.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 public class Staff {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue()
     @Column(name = "staff_id")
     private Long id;
 
@@ -38,4 +38,26 @@ public class Staff {
 
     @OneToMany(mappedBy = "staff")
     private final List<BoardReply> boardReplyList = new ArrayList<>();
+
+    /* 연관관계 메서드 */
+    public void setHospital(Hospital hospital) {
+        //comment: 기존 관계 제거
+        if (this.hospital != null) {
+            this.hospital.getStaffList().remove(this);
+        }
+
+        this.hospital = hospital;
+
+        //comment: 무한루프 방지
+        if (!hospital.getStaffList().contains(this)) {
+            hospital.getStaffList().add(this);
+        }
+    }
+
+    public void addBoardReply(BoardReply boardReply) {
+        this.boardReplyList.add(boardReply);
+        if (boardReply.getStaff() != this) { //무한루프에 빠지지 않도록 체크
+            boardReply.setStaff(this);
+        }
+    }
 }


### PR DESCRIPTION
1. 모든 엔티티별로 연관관계 편의 메서드를 개발하였습니다.
  - 모든 관계는 양방향으로 정의하였습니다.
  - 양쪽에 연관관계 편의 메서드를 생성하여 접근성을 높였습니다.
  - 연관관계 수정 시 기존 관계를 제거하는 로직을 추가하였습니다.
  - 양쪽에 메서드가 있다보니 무한루프를 체크하는 코드를 추가하였습니다.

<br/>

2. 모든 엔티티의 기본 키 생성 전략을 수정하였습니다.
  - 기존 : IDENTITY
  - 수정 : AUTO (default)