### PR TITLE
test: 회원가입 시 이메일 중복 검증 테스트

### DIFF
--- a/src/test/java/io/wisoft/capstonedesign/service/MemberServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package io.wisoft.capstonedesign.service;
 
 import io.wisoft.capstonedesign.domain.Member;
+import io.wisoft.capstonedesign.exception.DuplicateMemberException;
 import io.wisoft.capstonedesign.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -32,5 +33,19 @@ public class MemberServiceTest {
         //then -- 검증
         //assertEquals(member, memberRepository.findOne(signUpId));
         Assertions.assertThat(member).isEqualTo(memberRepository.findOne(signUpId));
+    }
+
+    @Test(expected = DuplicateMemberException.class)
+    public void 회원중복검증() throws Exception {
+        //given -- 조건
+        Member member1 = Member.newInstance("ldy_1204@naver.com", "1111", "0000");
+        Member member2 = Member.newInstance("ldy_1204@naver.com", "2222", "0000");
+
+        //when -- 동작
+        memberService.signUp(member1);
+        memberService.signUp(member2);
+
+        //then -- 검증
+        fail("회원의 이메일이 중복되어 예외가 발생해야 한다.");
     }
 }


### PR DESCRIPTION
회원가입 시 이메일이 기존 회원과 중복되는지 검증하는 테스트를 작성하였습니다.
- 중복될 경우 → `DuplicateMemberException`이 발생해야 합니다.