### PR TITLE
test: 회원 닉네임 중복 검증 로직 추가

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/service/MemberService.java
+++ b/src/main/java/io/wisoft/capstonedesign/service/MemberService.java
@@ -30,7 +30,8 @@ public class MemberService {
 
     private void validateDuplicateMember(Member member) {
         List<Member> findMembersByEmail = memberRepository.findByEmail(member.getEmail());
-        if (findMembersByEmail.size() != 0) {
+        List<Member> findMembersByNickname = memberRepository.findByNickname(member.getNickname());
+        if (findMembersByEmail.size() != 0 || findMembersByNickname.size() != 0) {
             throw new DuplicateMemberException("중복 회원 발생 : 이미 존재하는 회원입니다.");
         }
     }

--- a/src/test/java/io/wisoft/capstonedesign/service/MemberServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/service/MemberServiceTest.java
@@ -22,7 +22,8 @@ public class MemberServiceTest {
     @Autowired MemberRepository memberRepository;
 
     @Test
-    public void 회원가입() throws Exception {
+    public void 회원_가입() throws Exception {
+
         //given -- 조건
         Member member = Member.newInstance("test", "ldy_1204@naver.com", "1111", "0000");
 
@@ -35,10 +36,11 @@ public class MemberServiceTest {
     }
 
     @Test(expected = DuplicateMemberException.class)
-    public void 회원중복검증() throws Exception {
+    public void 회원_이메일_중복_검증() throws Exception {
+
         //given -- 조건
-        Member member1 = Member.newInstance("test", "ldy_1204@naver.com", "1111", "0000");
-        Member member2 = Member.newInstance("test", "ldy_1204@naver.com", "2222", "0000");
+        Member member1 = Member.newInstance("test1", "ldy_1204@naver.com", "1111", "0000");
+        Member member2 = Member.newInstance("test2", "ldy_1204@naver.com", "2222", "0000");
 
         //when -- 동작
         memberService.signUp(member1);
@@ -46,5 +48,20 @@ public class MemberServiceTest {
 
         //then -- 검증
         fail("회원의 이메일이 중복되어 예외가 발생해야 한다.");
+    }
+
+    @Test(expected = DuplicateMemberException.class)
+    public void 회원_닉네임_중복_검증() throws Exception {
+
+        //given -- 조건
+        Member member1 = Member.newInstance("test1", "111@naver.com", "1111", "0000");
+        Member member2 = Member.newInstance("test1", "222naver.com", "2222", "0000");
+
+        //when -- 동작
+        memberService.signUp(member1);
+        memberService.signUp(member2);
+
+        //then -- 검증
+        fail("회원의 닉네임이 중복되어 예외가 발생해야 한다.");
     }
 }


### PR DESCRIPTION
기존에 회원의 이메일만 중복 검증을 하던 로직에 닉네임 중복 검증 로직을 추가하였습니다.