### PR TITLE
feat: 이메일 인증 코드 및 임시 비밀번호 발급 로직 개발(#109)

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/mail/application/EmailService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/mail/application/EmailService.java
@@ -1,5 +1,6 @@
 package io.wisoft.capstonedesign.domain.mail.application;
 
 public interface EmailService {
-    void sendSimpleMessage(String to, String subject, String text);
+    void sendCertificationCode(final String email);
+    void sendResetPassword(final String to);
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/mail/application/EmailServiceImpl.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/mail/application/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package io.wisoft.capstonedesign.domain.mail.application;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
@@ -8,6 +9,9 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.Random;
+
+@Slf4j
 @Service("EmailService")
 public class EmailServiceImpl implements EmailService {
 
@@ -17,18 +21,55 @@ public class EmailServiceImpl implements EmailService {
     @Autowired
     private JavaMailSender emailSender;
 
+    private static final String EMAIL_CERTIFICATION_SUBJECT = "AVOCADO 이메일 인증 코드입니다.";
+    private static final String PASSWORD_RESET_SUBJECT = "AVOCADO 임시 비밀번호입니다.";
+
     @Async
-    public void sendSimpleMessage(final String to, final String subject, final String text) {
+    public void sendCertificationCode(final String to) {
+        sendEmail(to, EMAIL_CERTIFICATION_SUBJECT);
+        log.info(to + "으로 인증 코드를 발송합니다.");
+    }
+
+    @Async
+    public void sendResetPassword(final String to) {
+        sendEmail(to, PASSWORD_RESET_SUBJECT);
+        log.info(to + "으로 임시 비밀번호를 발급합니다.");
+    }
+
+    private void sendEmail(final String to, final String subject) {
         try {
             SimpleMailMessage message = new SimpleMailMessage();
             message.setFrom(AVOCADO_ADDRESS);
             message.setTo(to);
             message.setSubject(subject);
-            message.setText(text);
+            message.setText(createCertificationCode());
 
             emailSender.send(message);
         } catch (MailException exception) {
             exception.printStackTrace();
         }
+    }
+
+    private String createCertificationCode() {
+        StringBuilder stringBuilder = new StringBuilder();
+        Random random = new Random();
+
+        for (int i = 0; i < 8; i++) { // 인증코드 8자리
+            int index = random.nextInt(3); // 0~2 까지 랜덤
+
+            switch (index) {
+                //  a~z  (ex. 1+97=98 => (char)98 = 'b')
+                case 0 -> stringBuilder.append((char) ((int) (random.nextInt(26)) + 97));
+
+                //  A~Z
+                case 1 -> stringBuilder.append((char) ((int) (random.nextInt(26)) + 65));
+
+                // 0~9
+                case 2 -> stringBuilder.append((random.nextInt(10)));
+            }
+        }
+        String code = stringBuilder.toString();
+        log.info("code : " + code);
+        return code;
     }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/mail/persistence/MailObject.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/mail/persistence/MailObject.java
@@ -10,7 +10,5 @@ import lombok.Getter;
 public class MailObject {
     @Email @NotNull
     @Size(min = 1, message = "Please, set an email address to send the message to it")
-    private String to;
-    private String subject;
-    private String text;
+    private String email;
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/mail/web/MailController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/mail/web/MailController.java
@@ -14,9 +14,15 @@ public class MailController {
 
     @Autowired public EmailService emailService;
 
-    @PostMapping("/mail/send")
-    public ResponseEntity<String> createMail(@RequestBody MailObject mailObject) {
-        emailService.sendSimpleMessage(mailObject.getTo(), mailObject.getSubject(), mailObject.getText());
-        return ResponseEntity.ok("ok");
+    @PostMapping("/mail/certification")
+    public ResponseEntity<String> certificateEmail(@RequestBody final MailObject mailObject) {
+        emailService.sendCertificationCode(mailObject.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/mail/password")
+    public ResponseEntity<String> resetPassword(@RequestBody final MailObject mailObject) {
+        emailService.sendResetPassword(mailObject.getEmail());
+        return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
## What is this PR? 📍
이메일 인증 코드 및 임시 비밀번호 발급 로직을 개발합니다.
무작위로 생성된 코드를 비밀번호 찾기 기능 함께 사용할 수 있을 것 같아 함께 개발하였습니다.

<br/>

## Changes 🔍
임시코드 생성 및 메일 발송을 로그로 확인하기 위해 `@Slf4j` 어노테이션을 사용하였습니다.
기존에 만든 EmailObject(dto)에서 필요없는 속성들을 제거합니다.

<br/>
 
## Todo 🗓️
- [ ] 이메일 인증 과정에서 발급된 임시코드를 검증하는 로직을 개발해야 합니다.
- [ ] 또한 임시 비밀번호 발급시, 해당 이메일의 회원의 비밀번호를 임시 비밀번호로 업데이트하도록 로직을 수정해야 합니다.

<br/>