### PR TITLE
feat: 회원&의료진 통합 로그아웃 구현(#117)

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/web/AuthController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/web/AuthController.java
@@ -9,6 +9,7 @@ import io.wisoft.capstonedesign.domain.auth.web.dto.TokenResponse;
 import io.wisoft.capstonedesign.domain.auth.web.dto.CreateStaffRequest;
 import io.wisoft.capstonedesign.domain.auth.web.dto.CreateStaffResponse;
 import io.wisoft.capstonedesign.global.exception.IllegalValueException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,6 +40,22 @@ public class AuthController {
     public ResponseEntity<TokenResponse> loginMember(@RequestBody @Valid final LoginRequest request) {
         final String token = authService.loginMember(request);
         return ResponseEntity.ok(new TokenResponse(token, "bearer"));
+    }
+
+
+    /**
+     * 로그아웃
+     */
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<String> logoutMember(HttpServletRequest request) {
+        //TODO
+        boolean result = authService.logout(request);
+
+        if (result) {
+            return ResponseEntity.ok("logout success");
+        } else {
+            return ResponseEntity.badRequest().body("bad request");
+        }
     }
 
 

--- a/src/main/java/io/wisoft/capstonedesign/global/config/WebMvcConfig.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/config/WebMvcConfig.java
@@ -19,9 +19,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry){
-        logger.info(">>> 인터셉터 등록");
+        logger.info("인터셉터 등록");
 
         registry.addInterceptor(bearerAuthInterceptor)
+
+                .addPathPatterns("api/auth/logout")
+
                 .addPathPatterns("/api/members")
                 .addPathPatterns("/api/members/**") //마이페이지가 여기에 같이 포함
 

--- a/src/main/java/io/wisoft/capstonedesign/global/interceptor/BearerAuthInterceptor.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/interceptor/BearerAuthInterceptor.java
@@ -31,7 +31,7 @@ public class BearerAuthInterceptor implements HandlerInterceptor {
             final HttpServletResponse response,
             final Object handler) throws Exception {
 
-        logger.info(">>> interceptor.preHandle 호출");
+        logger.info("interceptor.preHandle 호출");
 
         final String token = authExtractor.extract(request, "Bearer");
 

--- a/src/main/java/io/wisoft/capstonedesign/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/jwt/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package io.wisoft.capstonedesign.global.jwt;
 
 import io.jsonwebtoken.*;
 
+import io.wisoft.capstonedesign.global.exception.token.NotExistTokenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 @Component
 public class JwtTokenProvider {
@@ -16,6 +19,8 @@ public class JwtTokenProvider {
     private String secretKey;
     private long validityInMilliseconds;
     private final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
+
+    private Set<String> blackList = new HashSet<>();
 
     public JwtTokenProvider(
             @Value("${security.jwt.token.secret-key}") final String secretKey,
@@ -33,12 +38,15 @@ public class JwtTokenProvider {
         logger.info("validity: {}", validity);
 
 
-        return Jwts.builder()
+        String token = Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(validity)
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
+
+        logger.info("생성된 JWT: {}", token);
+        return token;
     }
 
     /** 토큰에서 값 추출 */
@@ -54,12 +62,34 @@ public class JwtTokenProvider {
         try {
             Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
 
+            /** 만료시간이 지났을 경우 */
             if (claims.getBody().getExpiration().before(new Date())) {
                 return false;
             }
+
+            /** 로그아웃 요청한 토큰(= 블랙리스트에 포함)일 경우 */
+            if (blackList.contains(token)) {
+                return false;
+            }
+
             return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    public void addBlackList(final String token) throws IllegalAccessException {
+
+        if (blackList.contains(token)) {
+            logger.error("이미 로그아웃된 토큰입니다.");
+            throw new IllegalAccessException("이미 로그아웃된 토큰입니다.");
+        }
+
+        if (!validateToken(token)) {
+            logger.error("유효하지 않은 토큰");
+            throw new NotExistTokenException("토큰이 존재하지 않음");
+        }
+
+        blackList.add(token);
     }
 }


### PR DESCRIPTION
## What is this PR? 📍
회원 및 의료진 통합 로그아웃을 구현하였습니다.
JwtTokenProvider 내에 blackList set을 만들어 로그아웃 요청한 토큰들을 보관합니다.

로그아웃(= `addBlackList()`) 조건은 아래와 같다.
1. 유효하지 않은 토큰일 경우 예외를 발생시킨다.
2. 이미 로그아웃 처리된 토큰이 중복 요청을 보낼 경우 예외를 발생시킨다.
3. 1번과 2번에 해당되지 않을 경우 로그아웃 처리를 한다.

<br/>

## Changes 🔍
- `AuthController` , `AuthService` : logout API 추가
- `WebMvcConfig` : `/logout` 의 요청을 보낼 경우 토큰이 필요하도록 권한 설정
- `JwtTokenProvider` : `blackList` 셋 & `addBlackList()` 추가


<br/>
 
## Todo 🗓️
- [ ] 단순 권한 설정이 아닌, 회원인지 의료진인지 구별하여 권한 부여하도록 설정하기

<br/>