### PR TITLE
fix: CompletableFuture의 동기 호출을 이용하던 메서드를 논블록 호출로 수정함으로써 성능 개선

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/appointment/persistence/Appointment.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/appointment/persistence/Appointment.java
@@ -24,8 +24,6 @@ public class Appointment extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private HospitalDept dept;
 
-    //pg 사용시 @Lob 지우고, @Column(nullable = false, columnDefinition="TEXT")로 바꾸기
-    @Lob
     @Column(name = "appt_comment", nullable = false, columnDefinition="TEXT")
     private String comment;
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/web/MailController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/web/MailController.java
@@ -24,11 +24,12 @@ public class MailController {
 
     @SwaggerApi(summary = "이메일 인증 코드 전송", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/mail/certification-code")
-    public ResponseEntity<String> sendCertificationCode(@RequestBody final MailObject mailObject) throws ExecutionException, InterruptedException {
-        final String code = CompletableFuture.supplyAsync(
-                () -> emailService.sendCertificationCode(mailObject.email())).get();
+    @PostMapping("/mail/certification-code-with-join")
+    public ResponseEntity<String> sendCertificationCode(@RequestBody final MailObject mailObject) {
+        final CompletableFuture<String> future = CompletableFuture.supplyAsync(
+                () -> emailService.sendCertificationCode(mailObject.email()));
 
+        final String code = future.join();
         return ResponseEntity.ok(code);
     }
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/web/MailController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/web/MailController.java
@@ -24,7 +24,7 @@ public class MailController {
 
     @SwaggerApi(summary = "이메일 인증 코드 전송", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/mail/certification-code-with-join")
+    @PostMapping("/mail/certification-code")
     public ResponseEntity<String> sendCertificationCode(@RequestBody final MailObject mailObject) {
         final CompletableFuture<String> future = CompletableFuture.supplyAsync(
                 () -> emailService.sendCertificationCode(mailObject.email()));

--- a/src/main/java/io/wisoft/capstonedesign/domain/board/persistence/Board.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/board/persistence/Board.java
@@ -25,8 +25,6 @@ public class Board extends BaseEntity {
     @Column(name = "board_title", nullable = false)
     private String title;
 
-    //pg 사용시 @Lob 지우고, @Column(nullable = false, columnDefinition="TEXT")로 바꾸기
-    @Lob
     @Column(name = "board_body", nullable = false, columnDefinition="TEXT")
     private String body;
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.concurrent.CompletableFuture;
+
 @Tag(name = "메인화면 검색")
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +24,10 @@ public class ChatGptController {
     @SwaggerApiFailWithAuth
     @PostMapping("/api/search")
     public ChatGptResponse sendMessage(@RequestBody final ChatRequest chatRequest) {
-        return chatGptService.askQuestion(chatRequest);
+        final CompletableFuture<ChatGptResponse> future = CompletableFuture.supplyAsync(
+                () -> chatGptService.askQuestion(chatRequest));
+
+        final ChatGptResponse response = future.join();
+        return response;
     }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/hospital/persistence/Hospital.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/hospital/persistence/Hospital.java
@@ -31,8 +31,7 @@ public class Hospital extends BaseEntity {
     @Column(name = "hosp_address", nullable = false)
     private String address;
 
-    @Column(name = "hosp_operatingtime", nullable = false, columnDefinition="TEXT")
-//    @Column(name = "hosp_operatingtime", columnDefinition="TEXT")
+    @Column(name = "hosp_operatingtime", columnDefinition="TEXT")
     private String operatingTime;
 
     @OneToMany(mappedBy = "hospital")

--- a/src/main/java/io/wisoft/capstonedesign/domain/review/persistence/Review.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/review/persistence/Review.java
@@ -25,8 +25,6 @@ public class Review extends BaseEntity {
     @Column(name = "review_title", nullable = false)
     private String title;
 
-    //pg 사용시 @Lob 지우고, @Column(nullable = false, columnDefinition="TEXT")로 바꾸기
-    @Lob
     @Column(name = "review_body", nullable = false, columnDefinition="TEXT")
     private String body;
 


### PR DESCRIPTION
## What is this PR? 📍
> 기존 코드와 비교
> 
- `get()` : `CompletableFuture`에서 동기적인 호출
    - 동기적인 호출은 메서드를 호출한 후 그 호출이 완료될 때까지 대기하는 방식을 의미!
    - 동기 호출은 호출한 코드의 흐름을 차단하고 다음 코드를 실행하지 않는다!
    
- `join()` 메서드는 `CompletableFuture`에서 블록킹하지 않는 호출
    - 블록킹하지 않는 호출은 호출한 후에 결과를 기다리지 않고 즉시 다음 코드를 실행하는 방식을 의미!
    - 호출한 코드는 결과가 준비되지 않았을 때 다른 작업을 수행할 수 있고, 비동기적으로 작업을 처리하고 병렬성을 활용하는 데 유용하다!

<br/>

**자세한 내용은 [아보카도 트러블슈팅](https://www.notion.so/leedongyeop/Avocado-287972df87fa4a8bb976bba7649919ca?p=9b65b617357c4b4f91e642474e1dcaad&pm=s)에서 볼 수 있습니다.**

<br/>

## Changes 🔍
> Jmeter를 이용해 성능 테스트!

- 아래 두 테스트 모두 1초에 100명의 사용자가 요청하도록 하였음.

    
- 기존에 `get()` 메서드를 이용하던 경우
    - 평균 시간 : 34548, 에러율 : 0.00%, 처리량 : 1.8/sec

- `join()` 메서드를 이용해 비동기로 동작하도록 개선
    - 평균 시간 : 17831, 에러율 : 0.00%, 처리량 : 2.9/sec


<br/>
 
## Todo 🗓️
- [ ] 모던 자바 인 액션 17장까지 마무리하기

<br/>