### PR TITLE
feat: 커스텀 Executor를 만들고 스레드 풀 설정을 변경 및 비동기 작업시 커스텀 스레드풀 사용하도록 변경(#142)

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
@@ -7,6 +7,8 @@ import io.wisoft.capstonedesign.domain.chatgpt.web.dto.ChatRequest;
 import io.wisoft.capstonedesign.global.annotation.swagger.SwaggerApi;
 import io.wisoft.capstonedesign.global.annotation.swagger.SwaggerApiFailWithAuth;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,13 +21,14 @@ import java.util.concurrent.CompletableFuture;
 public class ChatGptController {
 
     private final ChatGptService chatGptService;
+    @Qualifier("asyncExecutor") private final ThreadPoolTaskExecutor executor;
 
     @SwaggerApi(summary = "OpenAI를 이용한 메인화면 검색", implementation = ChatGptResponse.class)
     @SwaggerApiFailWithAuth
     @PostMapping("/api/search")
     public ChatGptResponse sendMessage(@RequestBody final ChatRequest chatRequest) {
         final CompletableFuture<ChatGptResponse> future = CompletableFuture.supplyAsync(
-                () -> chatGptService.askQuestion(chatRequest));
+                () -> chatGptService.askQuestion(chatRequest), executor);
 
         final ChatGptResponse response = future.join();
         return response;

--- a/src/main/java/io/wisoft/capstonedesign/global/config/ThreadPoolConfig.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/config/ThreadPoolConfig.java
@@ -1,0 +1,22 @@
+package io.wisoft.capstonedesign.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class ThreadPoolConfig {
+
+    @Bean
+    public ThreadPoolTaskExecutor asyncExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("AsyncExecutor-");
+        executor.initialize();
+
+        return executor;
+    }
+}


### PR DESCRIPTION
## What is this PR? 📍
CompletableFuture를 사용하여 비동기 API의 성능을 향상시키려면 여러 방법이 있지만 그 중 한가지는 **직접 Executor를 지정하는 것이다.

<br/>

> 스레드 풀의 설정을 조정할 때는 프로젝트의 요구사항과 환경을 고려해야 한다.
1. 동시성 요구사항 : 동시에 처리해야 하는 작업의 수를 고려
2. 하드웨어 리소스 : 리소스가 제한적인 경우 너무 많은 스레드를 만들면 안된다.
3. 작업의 성격 : CPU 바운드 작업인지, I/O 바운드 작업인지, 네트워크 작업인지 파악하기
4. 응답 시간 요구사항 : 작업 처리 시간이 짧고 빠른 응답이 필요한 경우 스레드 풀의 크기를 작게 설정하여 작업 간의 경합을 줄이고 응답 시간을 최소화할 수 있다.
5. 부하 테스트 : 실제 부하 테스트를 수행하여 적절한 설정을 찾을 수 있다.

<br/>

<br/>

따라서 직접 커스텀 Executor를 만들고, 기본 스레드 풀 설정보다 스레드 개수를 줄여 응답 시간을 최소화하도록 하였습니다.

<br/>

## Changes 🔍
비동기 작업(이메일로 인증 코드 전송 & ChatGPT에 질문하기) 기능 동작 시에만 커스텀 Executor의 스레드풀을 이용하도록 변경합니다.


<br/>
 
## Todo 🗓️

<br/>