### PR TITLE
feat: Java 9에서 지원하는 CompletableFuture API : orTimeout 메서드로 시간 제한 설정(#142)

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 @Tag(name = "메인화면 검색")
 @RestController
@@ -28,7 +29,8 @@ public class ChatGptController {
     @PostMapping("/api/search")
     public ChatGptResponse sendMessage(@RequestBody final ChatRequest chatRequest) {
         final CompletableFuture<ChatGptResponse> future = CompletableFuture.supplyAsync(
-                () -> chatGptService.askQuestion(chatRequest), executor);
+                () -> chatGptService.askQuestion(chatRequest), executor)
+                .orTimeout(3, TimeUnit.SECONDS);
 
         final ChatGptResponse response = future.join();
         return response;


### PR DESCRIPTION
## What is this PR? 📍
Future의 계산 결과를 읽을 때는 무한정 기다리는 상황이 발생할 수 있으므로 블록을 하지 않는 것이 좋습니다.
→ Java 9에서 CompletableFuture가 제공하는 몇 가지 기능들을 이용해 이 문제를 해결할 수 있는데,
→ `orTimeout` 메서드로 시간 제한을 설정하여, 오래 걸리는 작업일 경우 TimeoutException이 발생되도록 하였습니다.

<br/>

## Changes 🔍
이메일 인증 코드 전송 기능과 ChatGPT 기반 질문 기능에 시간 제한을 3초로 설정

<br/>
 
## Todo 🗓️

<br/>