### PR TITLE
feat: 회의를 통해 정한 병과 전달 방식에 맞춰 DeptMapper 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
 
 
 	//java mail
-	implementation 'jakarta.activation:jakarta.activation-api'         //애플리케이션 실행 x / 테스트 실행 o
-//	implementation 'jakarta.activation:jakarta.activation-api:2.0.0'   //애플리케이션 실행 o / 테스트 실행 x
+//	implementation 'jakarta.activation:jakarta.activation-api'         //애플리케이션 실행 x / 테스트 실행 o
+	implementation 'jakarta.activation:jakarta.activation-api:2.0.0'   //애플리케이션 실행 o / 테스트 실행 x
 	implementation ('org.springframework.boot:spring-boot-starter-mail') {
 		exclude group: 'com.sun.activation', module: 'javax.activation'
 	}

--- a/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/application/HealthInfoService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/application/HealthInfoService.java
@@ -8,6 +8,7 @@ import io.wisoft.capstonedesign.domain.healthinfo.persistence.HealthInfoReposito
 import io.wisoft.capstonedesign.domain.healthinfo.web.dto.CreateHealthInfoRequest;
 import io.wisoft.capstonedesign.domain.staff.persistence.Staff;
 import io.wisoft.capstonedesign.domain.staff.application.StaffService;
+import io.wisoft.capstonedesign.global.mapper.DeptMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -67,26 +68,17 @@ public class HealthInfoService {
     }
 
 
-    /** 특정 병과의 건강정보 목록을 페이지별로 조회하기 */
-    public Page<HealthInfo> findAllByDeptUsingPaging(final String dept, final Pageable pageable) {
+    /**
+     * 특정 병과의 건강정보 목록을 페이지별로 조회하기
+     */
+    public Page<HealthInfo> findAllByDeptUsingPaging(final String deptNumber, final Pageable pageable) {
 
-        validateDept(dept);
-        return healthInfoRepository.findAllByDeptUsingPaging(HospitalDept.valueOf(dept), pageable);
+        return healthInfoRepository.findAllByDeptUsingPaging(DeptMapper.numberToDept(deptNumber), pageable);
     }
 
-    private boolean validateDept(final String dept) {
-
-        final Iterator<HospitalDept> iterator = Arrays.stream(HospitalDept.values()).iterator();
-
-        while (iterator.hasNext()) {
-            if (iterator.next().getCode().equals(dept.toUpperCase())) {
-                return true;
-            }
-        }
-        throw new IllegalValueException("일치하는 hospitalDept가 없습니다.");
-    }
-
-    /** 건강정보 목록을 페이지별로 조회하기 */
+    /**
+     * 건강정보 목록을 페이지별로 조회하기
+     */
     public Page<HealthInfo> findByUsingPaging(final Pageable pageable) {
         return healthInfoRepository.findByUsingPaging(pageable);
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/web/HealthInfoApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/web/HealthInfoApiController.java
@@ -52,25 +52,19 @@ public class HealthInfoApiController {
 
 
     /**
-     * ex) /api/health-infos/department?page=0&size=5&sort=createAt,desc
+     * ex) /api/health-infos?dept=1&page=0&size=5&sort=createAt,desc
+     * ex) /api/health-infos?page=0&size=5&sort=createAt,desc
      */
     @SwaggerApi(summary = "특정 병과의 건강 정보 목록 페이징 조회", implementation = Page.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/health-infos/department")
-    public Page<HealthInfoDto> healthInfosByDepartmentUsingPaging(
-            @RequestBody @Valid final HealthInfoByDepartmentRequest request, final Pageable pageable) {
-
-        return healthInfoService.findAllByDeptUsingPaging(request.department(), pageable).map(HealthInfoDto::new);
-    }
-
-
-    /**
-     * ex) /api/health-infos?page=0&size=5&sort=createAt,desc
-     */
-    @SwaggerApi(summary = "건강정보 목록을 페이지별로 조회하기", implementation = Page.class)
-    @SwaggerApiFailWithoutAuth
     @GetMapping("/api/health-infos")
-    public Page<HealthInfoDto> healthInfosUsingPaging(final Pageable pageable) {
-        return healthInfoService.findByUsingPaging(pageable).map(HealthInfoDto::new);
+    public Page<HealthInfoDto> healthInfosByDepartmentUsingPaging(
+            @RequestParam(name = "dept", required = false) final String deptNumber, final Pageable pageable) {
+
+        if (deptNumber == null) {
+            return healthInfoService.findByUsingPaging(pageable).map(HealthInfoDto::new);
+        }
+
+        return healthInfoService.findAllByDeptUsingPaging(deptNumber, pageable).map(HealthInfoDto::new);
     }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/web/dto/HealthInfoByDepartmentRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/web/dto/HealthInfoByDepartmentRequest.java
@@ -1,4 +1,0 @@
-package io.wisoft.capstonedesign.domain.healthinfo.web.dto;
-
-
-public record HealthInfoByDepartmentRequest(String department) { }

--- a/src/main/java/io/wisoft/capstonedesign/global/mapper/DeptMapper.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/mapper/DeptMapper.java
@@ -1,0 +1,62 @@
+package io.wisoft.capstonedesign.global.mapper;
+
+
+import io.wisoft.capstonedesign.global.enumeration.HospitalDept;
+
+public class DeptMapper {
+
+    public static HospitalDept numberToDept(final String number) {
+
+        final HospitalDept value =
+                switch (number) {
+                    case "1" -> {
+                        yield HospitalDept.DENTAL;
+                    }
+                    case "2" -> {
+                        yield HospitalDept.OPHTHALMOLOGY;
+                    }
+                    case "3" -> {
+                        yield HospitalDept.DERMATOLOGY;
+                    }
+                    case "4" -> {
+                        yield HospitalDept.PLASTIC_SURGERY;
+                    }
+                    case "5" -> {
+                        yield HospitalDept.OBSTETRICS;
+                    }
+                    case "6" -> {
+                        yield HospitalDept.PSYCHIATRY;
+                    }
+                    case "7" -> {
+                        yield HospitalDept.ORTHOPEDICS;
+                    }
+                    case "8" -> {
+                        yield HospitalDept.NEUROSURGERY;
+                    }
+                    case "9" -> {
+                        yield HospitalDept.SURGICAL;
+                    }
+                    case "10" -> {
+                        yield HospitalDept.NEUROLOGY;
+                    }
+                    case "11" -> {
+                        yield HospitalDept.PEDIATRIC;
+                    }
+                    case "12" -> {
+                        yield HospitalDept.INTERNAL_MEDICINE;
+                    }
+                    case "13" -> {
+                        yield HospitalDept.OTOLARYNGOLOGY;
+                    }
+                    case "14" -> {
+                        yield HospitalDept.UROLOGY;
+                    }
+                    case "15" -> {
+                        yield HospitalDept.ORIENTAL_MEDICAL;
+                    }
+                    default -> throw new IllegalStateException("Unexpected value: " + number);
+                };
+
+        return value;
+    }
+}


### PR DESCRIPTION
## What is this PR? 📍
건강 정보 및 리뷰 조회시 특정 병과에 관련된 정보만 볼 수 있는 기능이 있습니다.
"치과"에 해당하는 병원을 보려고 할 시 데이터를 전달하는 방법 3가지

1. Body에 { "dept" : "DENTAL" } 전달하기
2. /api/reviews?dept=DENTAL 로 전달하기
3. /api/reviews?dept=1로 전달하기

3번의 경우, 숫자를 미리 협의한다면 좋은 통신 방법이 될 것 같아 결정하였습니다! 
(산부인과, 비뇨기과 등의 경우 영어가 오히려 낯설어 통신하기가 힘들다)

따라서 전달받은 숫자 데이터를 HospitalDept enum 타입으로 변경하기 위한 Mapper를 개발합니다.

<br/>

## Changes 🔍
새로운 방식에 맞춰 기존에 `모든 건강정보 조회`와 `특정 병과에 해당하는 건강정보 조회` url을 통합


<br/>
 
## Todo 🗓️

<br/>