### PR TITLE
feat: 결제 정보 저장 유스케이스 구현(#155)

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/appointment/application/AppointmentService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/appointment/application/AppointmentService.java
@@ -74,7 +74,7 @@ public class AppointmentService {
         }
     }
 
-    private static Appointment createAppointment(
+    private Appointment createAppointment(
             final CreateAppointmentRequest request, final Member member, final Hospital hospital) {
 
         return Appointment.builder()

--- a/src/main/java/io/wisoft/capstonedesign/domain/appointment/application/AppointmentService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/appointment/application/AppointmentService.java
@@ -9,6 +9,7 @@ import io.wisoft.capstonedesign.domain.member.persistence.Member;
 import io.wisoft.capstonedesign.global.enumeration.HospitalDept;
 import io.wisoft.capstonedesign.global.enumeration.status.PayStatus;
 import io.wisoft.capstonedesign.global.exception.illegal.IllegalDeptException;
+import io.wisoft.capstonedesign.global.exception.illegal.IllegalValueException;
 import io.wisoft.capstonedesign.global.exception.nullcheck.NullAppointmentException;
 import io.wisoft.capstonedesign.domain.hospital.application.HospitalService;
 import io.wisoft.capstonedesign.domain.member.application.MemberService;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -36,6 +38,8 @@ public class AppointmentService {
     @Transactional
     public Long save(
             final CreateAppointmentRequest request) {
+
+        validateAppointmentDate(request.appointmentDate());
 
         //엔티티 조회
         final Member member = memberService.findById(request.memberId());
@@ -74,6 +78,12 @@ public class AppointmentService {
         }
     }
 
+    private void validateAppointmentDate(final LocalDateTime appointmentDate) {
+        if (appointmentDate.isBefore(LocalDateTime.now())) {
+            throw new IllegalValueException("요청된 예약일자가 현재 날짜보다 이전입니다.");
+        }
+    }
+
     private Appointment createAppointment(
             final CreateAppointmentRequest request, final Member member, final Hospital hospital) {
 
@@ -85,6 +95,7 @@ public class AppointmentService {
                 .appointName(request.appointName())
                 .appointPhonenumber(request.appointPhonenumber())
                 .payStatus(PayStatus.NONE)
+                .appointmentDate(request.appointmentDate())
                 .build();
     }
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/appointment/persistence/Appointment.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/appointment/persistence/Appointment.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 
 @Entity
 @Getter
@@ -37,6 +39,9 @@ public class Appointment extends BaseEntity {
     @Column(name = "appt_pay_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private PayStatus payStatus;
+
+    @Column(name = "appt_date", nullable = false)
+    private LocalDateTime appointmentDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -84,7 +89,8 @@ public class Appointment extends BaseEntity {
             final String comment,
             final String appointName,
             final String appointPhonenumber,
-            final PayStatus payStatus) {
+            final PayStatus payStatus,
+            final LocalDateTime appointmentDate) {
 
         Appointment appointment = new Appointment();
         appointment.setMember(member);
@@ -94,6 +100,7 @@ public class Appointment extends BaseEntity {
         appointment.appointName = appointName;
         appointment.appointPhonenumber = appointPhonenumber;
         appointment.payStatus = payStatus;
+        appointment.appointmentDate = appointmentDate;
 
         appointment.createEntity();
         return appointment;
@@ -113,5 +120,9 @@ public class Appointment extends BaseEntity {
         this.appointPhonenumber = appointPhonenumber;
 
         this.updateEntity();
+    }
+
+    public void payment() {
+        this.payStatus = PayStatus.COMPLETED;
     }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/appointment/web/dto/CreateAppointmentRequest.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/appointment/web/dto/CreateAppointmentRequest.java
@@ -1,8 +1,11 @@
 package io.wisoft.capstonedesign.domain.appointment.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
 
 @Builder
 public record CreateAppointmentRequest(
@@ -11,5 +14,9 @@ public record CreateAppointmentRequest(
         @NotBlank String dept,
         @NotBlank String comment,
         @NotBlank String appointName,
-        @NotBlank String appointPhonenumber
-) {}
+        @NotBlank String appointPhonenumber,
+        @NotNull
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", shape = JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
+        LocalDateTime appointmentDate
+) {
+}

--- a/src/main/java/io/wisoft/capstonedesign/domain/board/application/BoardService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/board/application/BoardService.java
@@ -33,15 +33,19 @@ public class BoardService {
         //엔티티 조회
         final Member member = memberService.findById(request.memberId());
 
-        final Board board = Board.builder()
+        final Board board = createBoard(request, member);
+
+        boardRepository.save(board);
+        return board.getId();
+    }
+
+    private Board createBoard(final CreateBoardRequest request, final Member member) {
+        return Board.builder()
                 .member(member)
                 .title(request.title())
                 .body(request.body())
                 .dept(HospitalDept.valueOf(request.dept()))
                 .build();
-
-        boardRepository.save(board);
-        return board.getId();
     }
 
     /**

--- a/src/main/java/io/wisoft/capstonedesign/domain/boardreply/application/BoardReplyService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/boardreply/application/BoardReplyService.java
@@ -36,14 +36,19 @@ public class BoardReplyService {
         final Board board = boardService.findById(request.boardId());
         final Staff staff = staffService.findById(request.staffId());
 
+        final BoardReply boardReply = createBoardReply(request, board, staff);
+
+        boardReplyRepository.save(boardReply);
+        return boardReply.getId();
+    }
+
+    private BoardReply createBoardReply(final CreateBoardReplyRequest request, final Board board, final Staff staff) {
         final BoardReply boardReply = BoardReply.builder()
                 .board(board)
                 .staff(staff)
                 .reply(request.reply())
                 .build();
-
-        boardReplyRepository.save(boardReply);
-        return boardReply.getId();
+        return boardReply;
     }
 
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/application/HealthInfoService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/application/HealthInfoService.java
@@ -35,15 +35,19 @@ public class HealthInfoService {
 
         final Staff staff = staffService.findById(request.staffId());
 
-        final HealthInfo healthInfo = HealthInfo.builder()
+        final HealthInfo healthInfo = createHealthInfo(request, staff);
+
+        healthInfoRepository.save(healthInfo);
+        return healthInfo.getId();
+    }
+
+    private HealthInfo createHealthInfo(final CreateHealthInfoRequest request, final Staff staff) {
+        return HealthInfo.builder()
                 .staff(staff)
                 .healthInfoPath(request.healthInfoPath())
                 .title(request.title())
                 .dept(HospitalDept.valueOf(request.dept()))
                 .build();
-
-        healthInfoRepository.save(healthInfo);
-        return healthInfo.getId();
     }
 
     /**

--- a/src/main/java/io/wisoft/capstonedesign/domain/hospital/application/HospitalService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/hospital/application/HospitalService.java
@@ -26,15 +26,19 @@ public class HospitalService {
 
         validateDuplicateHospital(request);
 
-        final Hospital hospital = Hospital.builder()
+        final Hospital hospital = createHospital(request);
+
+        hospitalRepository.save(hospital);
+        return hospital.getId();
+    }
+
+    private Hospital createHospital(final CreateHospitalRequest request) {
+        return Hospital.builder()
                 .name(request.name())
                 .number(request.number())
                 .address(request.address())
                 .operatingTime(request.operatingTime())
                 .build();
-
-        hospitalRepository.save(hospital);
-        return hospital.getId();
     }
 
     private void validateDuplicateHospital(final CreateHospitalRequest request) {

--- a/src/main/java/io/wisoft/capstonedesign/domain/member/application/MemberMyPageService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/member/application/MemberMyPageService.java
@@ -21,10 +21,6 @@ public class MemberMyPageService {
     private final MemberMyPageRepository memberMyPageRepository;
 
     /**
-     *  회원 마이페이지 기능
-     */
-
-    /**
      * 자신이 쓴 리뷰 목록 페이징 조회
      */
     public Page<Review> findReviewsByMemberIdUsingPaging(final Long memberId, final Pageable pageable) {

--- a/src/main/java/io/wisoft/capstonedesign/domain/member/application/MemberService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/member/application/MemberService.java
@@ -33,6 +33,8 @@ public class MemberService {
 
         member.updatePassword(encryptHelper.encrypt(request.newPassword()));
     }
+
+
     private void validateMemberPassword(final Member member, final UpdateMemberPasswordRequest request) {
 
         if (!encryptHelper.isMatch(request.oldPassword(), member.getPassword())) {

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/application/PaymentService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/application/PaymentService.java
@@ -1,0 +1,45 @@
+package io.wisoft.capstonedesign.domain.payment.application;
+
+import com.siot.IamportRestClient.response.Payment;
+import io.wisoft.capstonedesign.domain.appointment.application.AppointmentService;
+import io.wisoft.capstonedesign.domain.appointment.persistence.Appointment;
+import io.wisoft.capstonedesign.domain.payment.persistence.PaymentEntity;
+import io.wisoft.capstonedesign.domain.payment.persistence.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final AppointmentService appointmentService;
+
+    @Transactional
+    public Long save(final Payment payment) {
+        //예약 정보 조회
+        final Long appointmentId = Long.valueOf(payment.getMerchantUid());
+        final Appointment appointment = appointmentService.findById(appointmentId);
+
+        //해당 예약건 결제
+        appointment.payment();
+
+        //결제 정보 생성(매핑) 후 저장
+        final PaymentEntity paymentEntity = paymentToPaymentEntity(payment);
+
+        return paymentRepository.save(paymentEntity).getId();
+    }
+
+    private PaymentEntity paymentToPaymentEntity(final Payment payment) {
+        final PaymentEntity paymentEntity = PaymentEntity.createPaymentEntity(
+                payment.getPgProvider(),
+                payment.getPayMethod(),
+                "아보카도 병원 예약금",
+                payment.getBuyerEmail(),
+                payment.getBuyerName()
+        );
+        return paymentEntity;
+    }
+}

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/persistence/PaymentEntity.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/persistence/PaymentEntity.java
@@ -1,0 +1,44 @@
+package io.wisoft.capstonedesign.domain.payment.persistence;
+
+import io.wisoft.capstonedesign.domain.appointment.persistence.Appointment;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "payment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String pg;
+    private String paymentMethod;
+    private String paymentName;
+    private String buyerEmail;
+    private String buyerName;
+
+    @OneToOne
+    @JoinColumn(name = "appt_id")
+    private Appointment appointment;
+
+    public static PaymentEntity createPaymentEntity(
+            final String pg,
+            final String paymentMethod,
+            final String paymentName,
+            final String buyerEmail,
+            final String buyerName) {
+
+        final PaymentEntity payment = new PaymentEntity();
+        payment.pg = pg;
+        payment.paymentMethod = paymentMethod;
+        payment.paymentName = paymentName;
+        payment.buyerEmail = buyerEmail;
+        payment.buyerName = buyerName;
+
+        return payment;
+    }
+}

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/persistence/PaymentRepository.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/persistence/PaymentRepository.java
@@ -1,0 +1,7 @@
+package io.wisoft.capstonedesign.domain.payment.persistence;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
+}

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
@@ -1,10 +1,10 @@
-package io.wisoft.capstonedesign.domain.appointment.web;
+package io.wisoft.capstonedesign.domain.payment.web;
 
 
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import com.siot.IamportRestClient.response.Payment;
-import io.wisoft.capstonedesign.domain.appointment.application.PaymentService;
+import io.wisoft.capstonedesign.domain.payment.application.PaymentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/io/wisoft/capstonedesign/domain/reviewreply/application/ReviewReplyService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/reviewreply/application/ReviewReplyService.java
@@ -36,14 +36,19 @@ public class ReviewReplyService {
         final Member member = memberService.findById(request.memberId());
         final Review review = reviewService.findById(request.reviewId());
 
+        final ReviewReply reviewReply = createReviewReply(request, member, review);
+
+        reviewReplyRepository.save(reviewReply);
+        return reviewReply.getId();
+    }
+
+    private ReviewReply createReviewReply(final CreateReviewReplyRequest request, final Member member, final Review review) {
         final ReviewReply reviewReply = ReviewReply.builder()
                 .member(member)
                 .review(review)
                 .reply(request.reply())
                 .build();
-
-        reviewReplyRepository.save(reviewReply);
-        return reviewReply.getId();
+        return reviewReply;
     }
 
 


### PR DESCRIPTION
## What is this PR? 📍
결제 후 응답으로 받은 정보들을 저장하는 로직을 추가하였습니다.

<br/>

## Changes 🔍
- 결제(payment) 도메인 로직을 예약(appointment) 패키지로부터 분리
- 예약 생성 과정에서 예약 날짜 필드 추가 및 직렬화 애너테이션 등록

<br/>
 
## Todo 🗓️
- [ ] 결제 취소 유스케이스 구현하기
- [ ] 결제 관련 비즈니스 로직 테스트 코드 작성하기

<br/>