### PR TITLE
feat : 결제 취소 API 개발 및 결제 정보 저장 과정에서 예외 발생시 결제 취소가 이루어지도록 설계

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/appointment/web/AppointmentApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/appointment/web/AppointmentApiController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "예약")
 @RestController
+@RequestMapping("/api/appointments")
 @RequiredArgsConstructor
 public class AppointmentApiController {
 
@@ -19,7 +20,7 @@ public class AppointmentApiController {
 
     @SwaggerApi(summary = "예약 저장", implementation = CreateAppointmentResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/appointments")
+    @PostMapping
     public CreateAppointmentResponse createAppointment(
             @RequestBody @Valid final CreateAppointmentRequest request) {
         return new CreateAppointmentResponse(appointmentService.save(request));
@@ -28,7 +29,7 @@ public class AppointmentApiController {
 
     @SwaggerApi(summary = "예약 삭제", implementation = DeleteAppointmentResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/appointments/{id}")
+    @DeleteMapping("/{id}")
     public DeleteAppointmentResponse deleteAppointment(@PathVariable("id") final Long id) {
         appointmentService.deleteAppointment(id);
         return new DeleteAppointmentResponse(id);
@@ -37,7 +38,7 @@ public class AppointmentApiController {
 
     @SwaggerApi(summary = "예약 수정", implementation = UpdateAppointmentResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/appointments/{id}")
+    @PatchMapping("/{id}")
     public UpdateAppointmentResponse updateAppointment(
             @PathVariable("id") final Long id,
             @RequestBody @Valid final UpdateAppointmentRequest request) {
@@ -48,7 +49,7 @@ public class AppointmentApiController {
 
     @SwaggerApi(summary = "예약 조회", implementation = Result.class)
     @SwaggerApiFailWithAuth
-    @GetMapping("/api/appointments/{id}/details")
+    @GetMapping("/{id}/details")
     public Result appointment(@PathVariable("id") final Long id) {
         return new Result(new AppointmentDto(appointmentService.findDetailById(id)));
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/application/AuthService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/application/AuthService.java
@@ -65,7 +65,7 @@ public class AuthService {
             final var mailAuthentication = mailAuthenticationRepository.findByEmail(request.email()).get();
             mailAuthenticationRepository.delete(mailAuthentication);
 
-            log.info(member.getNickname() + "님이 회원가입을 하셨습니다.");
+            log.info("{}님이 회원가입을 하셨습니다.", member.getNickname());
             return member.getId();
         } catch (DuplicateEmailException duplicateException) {
             duplicateException.printStackTrace();
@@ -89,14 +89,14 @@ public class AuthService {
             validatePassowrd(request, member.getPassword());
 
             token = jwtTokenProvider.createToken(member.getNickname());
-            log.info(member.getNickname() + "님이 로그인 하셨습니다.");
+            log.info("{}님이 로그인 하셨습니다.", member.getNickname());
 
             redisTemplate.opsForValue().set(
                     token, member.getNickname(),
                     LOGIN_EXPIRED_TIME,
                     TimeUnit.SECONDS
             );
-            log.info("redis : 토큰(" + token + ")을 1시간동안 저장합니다.");
+            log.info("redis : 토큰{}을 1시간동안 저장합니다.", token);
 
         } catch (IllegalValueException e) {
             e.printStackTrace();
@@ -124,7 +124,7 @@ public class AuthService {
         final var mailAuthentication = mailAuthenticationRepository.findByEmail(request.email()).get();
         mailAuthenticationRepository.delete(mailAuthentication);
 
-        log.info(staff.getName() + "님이 가입 하셨습니다.");
+        log.info("{}님이 가입 하셨습니다.", staff.getName());
         return staff.getId();
     }
 
@@ -139,14 +139,14 @@ public class AuthService {
         validatePassowrd(request, staff.getPassword());
 
         final String token = jwtTokenProvider.createToken(staff.getName());
-        log.info(staff.getName() + "님이 로그인 하셨습니다.");
+        log.info("{}님이 로그인 하셨습니다.", staff.getName());
 
         redisTemplate.opsForValue().set(
                 token, staff.getName(),
                 LOGIN_EXPIRED_TIME,
                 TimeUnit.SECONDS
         );
-        log.info("redis : 토큰(" + token + ")을 1시간동안 저장합니다.");
+        log.info("redis : 토큰{}을 1시간동안 저장합니다.", token);
 
         return token;
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/application/EmailServiceImpl.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/application/EmailServiceImpl.java
@@ -59,9 +59,9 @@ public class EmailServiceImpl implements EmailService {
                 EXPIRED_TIME,
                 TimeUnit.SECONDS
         );
-        log.info("redis :  " + to + " 를 3분간 저장합니다.");
+        log.info("redis : {} 를 3분간 저장합니다.", to);
 
-        log.info(to + "으로 인증 코드를 발송합니다.");
+        log.info("{} 으로 인증 코드를 발송합니다.", to);
         return authenticateCode;
     }
 
@@ -119,7 +119,7 @@ public class EmailServiceImpl implements EmailService {
 
         member.updatePassword(encryptHelper.encrypt(temporaryPassword));
 
-        log.info(to + "으로 임시 비밀번호를 발급합니다.");
+        log.info("{}으로 임시 비밀번호를 발급합니다.", to);
     }
 
     @Async
@@ -130,7 +130,7 @@ public class EmailServiceImpl implements EmailService {
 
         staff.updatePassword(encryptHelper.encrypt(temporaryPassword));
 
-        log.info(to + "으로 임시 비밀번호를 발급합니다.");
+        log.info("{}으로 임시 비밀번호를 발급합니다.", to);
     }
 
     private String sendEmail(final String to, final String subject) {
@@ -162,7 +162,7 @@ public class EmailServiceImpl implements EmailService {
         final Random random = new Random();
 
         final String code = randomProcess(stringBuilder, random);
-        log.info("code : " + code);
+        log.info("code : {}", code);
         return code;
     }
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/web/AuthController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/web/AuthController.java
@@ -22,10 +22,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "인증")
 @RestController
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
@@ -36,7 +38,7 @@ public class AuthController {
 
     @SwaggerApi(summary = "회원 가입", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/api/auth/signup/members")
+    @PostMapping("/signup/members")
     public ResponseEntity<CreateMemberResponse> signupMember(@RequestBody @Valid final CreateMemberRequest request) {
 
         validatePassword(request.password1(), request.password2());
@@ -52,7 +54,7 @@ public class AuthController {
 
     @SwaggerApi(summary = "회원 로그인", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/api/auth/login/members")
+    @PostMapping("/login/members")
     public ResponseEntity<TokenResponse> loginMember(@RequestBody @Valid final LoginRequest request) {
         final String token = authService.loginMember(request);
         return ResponseEntity.ok(new TokenResponse(token, "bearer"));
@@ -61,7 +63,7 @@ public class AuthController {
 
     @SwaggerApi(summary = "로그아웃", implementation = ResponseEntity.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/auth/logout")
+    @PostMapping("/logout")
     public ResponseEntity<String> logoutMember(HttpServletRequest request) throws IllegalAccessException {
 
         final String token = authExtractor.extract(request, "Bearer");
@@ -73,7 +75,7 @@ public class AuthController {
 
     @SwaggerApi(summary = "의료진 가입", implementation = CreateStaffResponse.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/api/auth/signup/staff")
+    @PostMapping("/signup/staff")
     public CreateStaffResponse signupStaff(
             @RequestBody @Valid final CreateStaffRequest request) {
 
@@ -84,7 +86,7 @@ public class AuthController {
 
     @SwaggerApi(summary = "의료진 로그인", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/api/auth/login/staff")
+    @PostMapping("/login/staff")
     public ResponseEntity<TokenResponse> loginStaff(@RequestBody @Valid final LoginRequest request) {
         final String token = authService.loginStaff(request);
         return ResponseEntity.ok(new TokenResponse(token, "bearer"));

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/web/MailController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/web/MailController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
@@ -19,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 @Tag(name = "이메일 인증")
 @RestController
+@RequestMapping("/mail")
 @RequiredArgsConstructor
 public class MailController {
 
@@ -28,7 +30,7 @@ public class MailController {
 
     @SwaggerApi(summary = "이메일 인증 코드 전송", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/mail/certification-code")
+    @PostMapping("/certification-code")
     public ResponseEntity<String> sendCertificationCode(@RequestBody final MailObject mailObject) {
         final CompletableFuture<String> future = CompletableFuture.supplyAsync(
                         () -> emailService.sendCertificationCode(mailObject.email()), executor)
@@ -41,7 +43,7 @@ public class MailController {
 
     @SwaggerApi(summary = "이메일 인증", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/mail/certification-email")
+    @PostMapping("/certification-email")
     public ResponseEntity<String> certificateEmail(@RequestBody final CertificateMailRequest request) {
         emailService.certificateEmail(request);
         return ResponseEntity.ok("success");
@@ -50,7 +52,7 @@ public class MailController {
 
     @SwaggerApi(summary = "회원 비밀번호 찾기", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/mail/member/password")
+    @PostMapping("/member/password")
     public ResponseEntity<String> resetMemberPassword(@RequestBody final MailObject mailObject) {
         emailService.sendResetMemberPassword(mailObject.email());
         return ResponseEntity.ok("success");
@@ -58,7 +60,7 @@ public class MailController {
 
     @SwaggerApi(summary = "의료진 비밀번호 찾기", implementation = ResponseEntity.class)
     @SwaggerApiFailWithoutAuth
-    @PostMapping("/mail/staff/password")
+    @PostMapping("/staff/password")
     public ResponseEntity<String> resetStaffPassword(@RequestBody final MailObject mailObject) {
         emailService.sendResetStaffPassword(mailObject.email());
         return ResponseEntity.ok("success");

--- a/src/main/java/io/wisoft/capstonedesign/domain/board/web/BoardApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/board/web/BoardApiController.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 @Tag(name = "게시판")
 @RestController
+@RequestMapping("/api/boards")
 @RequiredArgsConstructor
 public class BoardApiController {
 
@@ -26,7 +27,7 @@ public class BoardApiController {
 
     @SwaggerApi(summary = "게시글 단건 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/boards/{id}/details")
+    @GetMapping("/{id}/details")
     public Result board(@PathVariable Long id) {
         return new Result(new BoardDto(boardService.findDetailById(id)));
     }
@@ -34,7 +35,7 @@ public class BoardApiController {
 
     @SwaggerApi(summary = "게시글 목록 조회 및 특정 병과 조회", implementation = Page.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/boards")
+    @GetMapping
     public Page<BoardListDto> boardsByDepartmentUsingPaging(
             @RequestParam(name = "dept", required = false) final List<String> deptNumberList, final Pageable pageable) {
 
@@ -48,7 +49,7 @@ public class BoardApiController {
 
     @SwaggerApi(summary = "게시글 작성", implementation = CreateBoardResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/boards")
+    @PostMapping
     public CreateBoardResponse createBoard(
             @RequestBody @Valid final CreateBoardRequest request) {
 
@@ -60,7 +61,7 @@ public class BoardApiController {
 
     @SwaggerApi(summary = "게시글 제목 및 본문 수정", implementation = UpdateBoardResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/boards/{id}")
+    @PatchMapping("/{id}")
     public UpdateBoardResponse updateBoardTitleBody(
             @PathVariable("id") final Long id,
             @RequestBody @Valid final UpdateBoardRequest request) {
@@ -74,7 +75,7 @@ public class BoardApiController {
 
     @SwaggerApi(summary = "게시글 삭제", implementation = DeleteBoardResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/boards/{id}")
+    @DeleteMapping("/{id}")
     public DeleteBoardResponse deleteBoard(@PathVariable("id") final Long id) {
 
         boardService.deleteBoard(id);

--- a/src/main/java/io/wisoft/capstonedesign/domain/boardreply/application/BoardReplyService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/boardreply/application/BoardReplyService.java
@@ -96,14 +96,14 @@ public class BoardReplyService {
     /**
      * 특정게시글의 댓글 목록 오름차순 조회
      */
-    public List<BoardReply> findByBoardIdOrderByCreateAsc() {
-        return boardReplyRepository.findByBoardIdOrderByCreateAsc();
+    public List<BoardReply> findByBoardIdOrderByCreateAsc(final Long id) {
+        return boardReplyRepository.findByBoardIdOrderByCreateAsc(id);
     }
 
     /**
      * 특정게시글의 댓글 목록 내림차순 조회
      */
-    public List<BoardReply> findByBoardIdOrderByCreateDesc() {
-        return boardReplyRepository.findByBoardIdOrderByCreateDesc();
+    public List<BoardReply> findByBoardIdOrderByCreateDesc(final Long id) {
+        return boardReplyRepository.findByBoardIdOrderByCreateDesc(id);
     }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/boardreply/persistence/BoardReplyRepository.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/boardreply/persistence/BoardReplyRepository.java
@@ -25,12 +25,12 @@ public interface BoardReplyRepository extends JpaRepository<BoardReply, Long> {
     /**
      * 특정게시글의 댓글 목록 오름차순 조회
      */
-    @Query("select br from BoardReply br order by br.createdAt asc")
-    List<BoardReply> findByBoardIdOrderByCreateAsc();
+    @Query("select br from BoardReply br join fetch br.board b where b.id = :id order by br.createdAt asc")
+    List<BoardReply> findByBoardIdOrderByCreateAsc(@Param("id") final Long id);
 
     /**
      * 특정게시글의 댓글 목록 내림차순 조회
      */
-    @Query("select br from BoardReply br order by br.createdAt desc")
-    List<BoardReply> findByBoardIdOrderByCreateDesc();
+    @Query("select br from BoardReply br join fetch br.board b where b.id = :id order by br.createdAt desc")
+    List<BoardReply> findByBoardIdOrderByCreateDesc(@Param("id") final Long id);
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/boardreply/web/BoardReplyApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/boardreply/web/BoardReplyApiController.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 @Tag(name = "게시판 댓글")
 @RestController
+@RequestMapping("/api/board-reply")
 @RequiredArgsConstructor
 public class BoardReplyApiController {
 
@@ -22,7 +23,7 @@ public class BoardReplyApiController {
 
     @SwaggerApi(summary = "게시판댓글 저장", implementation = CreateBoardReplyResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/board-reply")
+    @PostMapping
     public CreateBoardReplyResponse createBoardReply(
             @RequestBody @Valid final CreateBoardReplyRequest request) {
 
@@ -34,7 +35,7 @@ public class BoardReplyApiController {
 
     @SwaggerApi(summary = "게시판댓글 수정", implementation = UpdateBoardReplyResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/board-reply/{id}")
+    @PatchMapping("/{id}")
     public UpdateBoardReplyResponse updateBoardReply(
             @PathVariable("id") final Long id,
             @RequestBody @Valid final UpdateBoardReplyRequest request) {
@@ -47,7 +48,7 @@ public class BoardReplyApiController {
 
     @SwaggerApi(summary = "게시판댓글 삭제", implementation = DeleteBoardReplyResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/board-reply/{id}")
+    @DeleteMapping("/{id}")
     public DeleteBoardReplyResponse deleteBoardReply(@PathVariable("id") final Long id) {
         boardReplyService.deleteBoardReply(id);
         return new DeleteBoardReplyResponse(id);
@@ -56,7 +57,7 @@ public class BoardReplyApiController {
 
     @SwaggerApi(summary = "특정 게시판댓글 단건 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/board-reply/{id}/details")
+    @GetMapping("/{id}/details")
     public Result boardReply(@PathVariable("id") final Long id) {
         return new Result(new BoardReplyDto(boardReplyService.findDetailById(id)));
     }
@@ -64,9 +65,9 @@ public class BoardReplyApiController {
 
     @SwaggerApi(summary = "특정 게시글의 댓글 목록 오름차순 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/board-reply/board/{board-id}/create-asc")
+    @GetMapping("/board/{board-id}/create-asc")
     public Result boardReplyByBoardOrderByCreateAsc(@PathVariable("board-id") final Long id) {
-        return new Result(boardReplyService.findByBoardIdOrderByCreateAsc()
+        return new Result(boardReplyService.findByBoardIdOrderByCreateAsc(id)
                 .stream().map(BoardReplyDto::new)
                 .collect(Collectors.toList()));
     }
@@ -74,9 +75,9 @@ public class BoardReplyApiController {
 
     @SwaggerApi(summary = "특정 게시글의 댓글 목록 내림차순 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/board-reply/board/{board-id}/create-desc")
+    @GetMapping("/board/{board-id}/create-desc")
     public Result boardReplyByBoardOrderByCreateDesc(@PathVariable("board-id") final Long id) {
-        return new Result(boardReplyService.findByBoardIdOrderByCreateDesc()
+        return new Result(boardReplyService.findByBoardIdOrderByCreateDesc(id)
                 .stream().map(BoardReplyDto::new)
                 .collect(Collectors.toList()));
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/businfo/web/BusInfoApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/businfo/web/BusInfoApiController.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 @Tag(name = "셔틀버스")
 @RestController
+@RequestMapping("/api/bus-info")
 @RequiredArgsConstructor
 public class BusInfoApiController {
 
@@ -26,7 +27,7 @@ public class BusInfoApiController {
 
     @SwaggerApi(summary = "셔틀버스 정보 등록", implementation = CreateBusInfoResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/bus-info")
+    @PostMapping
     public CreateBusInfoResponse createBusInfo(
             @RequestBody @Valid final CreateBusInfoRequest request) {
         return new CreateBusInfoResponse(busInfoService.save(request));
@@ -35,7 +36,7 @@ public class BusInfoApiController {
 
     @SwaggerApi(summary = "셔틀 버스 단건 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/bus-info/{id}/details")
+    @GetMapping("/{id}/details")
     public Result busInfo(@PathVariable final Long id) {
         return new Result(new BusInfoDto(busInfoService.findById(id)));
     }
@@ -43,7 +44,7 @@ public class BusInfoApiController {
 
     @SwaggerApi(summary = "특정 지역 셔틀 버스 정보 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/bus-info/area/details")
+    @GetMapping("/area/details")
     public Result busInfoByArea(
             @RequestBody @Valid final BusInfoByAreaRequest request) {
 
@@ -70,7 +71,7 @@ public class BusInfoApiController {
 
     @SwaggerApi(summary = "셔틀 버스 정보 삭제", implementation = Result.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/bus-info/{id}")
+    @DeleteMapping("/{id}")
     public Result delete(@PathVariable final Long id) {
         busInfoService.delete(id);
         return new Result(new DeleteBusInfoResponse(id));

--- a/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/chatgpt/web/ChatGptController.java
@@ -30,7 +30,7 @@ public class ChatGptController {
     public ChatGptResponse sendMessage(@RequestBody final ChatRequest chatRequest) {
         final CompletableFuture<ChatGptResponse> future = CompletableFuture.supplyAsync(
                 () -> chatGptService.askQuestion(chatRequest), executor)
-                .orTimeout(5, TimeUnit.SECONDS);
+                .orTimeout(10, TimeUnit.SECONDS);
 
         return future.join();
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/web/HealthInfoApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/web/HealthInfoApiController.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 @Tag(name = "건강정보")
 @RestController
+@RequestMapping("/api/health-infos")
 @RequiredArgsConstructor
 public class HealthInfoApiController {
 
@@ -26,7 +27,7 @@ public class HealthInfoApiController {
 
     @SwaggerApi(summary = "건강 정보 등록", implementation = CreateHealthInfoResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/health-infos")
+    @PostMapping
     public CreateHealthInfoResponse createHealthInfo(
             @RequestBody @Valid final CreateHealthInfoRequest request) {
 
@@ -38,7 +39,7 @@ public class HealthInfoApiController {
 
     @SwaggerApi(summary = "건강 정보 삭제", implementation = DeleteHealthInfoResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/health-infos/{id}")
+    @DeleteMapping("/{id}")
     public DeleteHealthInfoResponse deleteHealthInfo(@PathVariable("id") final Long id) {
         healthInfoService.delete(id);
         return new DeleteHealthInfoResponse(id);
@@ -47,7 +48,7 @@ public class HealthInfoApiController {
 
     @SwaggerApi(summary = "건강 정보 단건 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/health-infos/{id}/details")
+    @GetMapping("/{id}/details")
     public Result healthInfo(@PathVariable("id") final Long id) {
         return new Result(new HealthInfoDto(healthInfoService.findDetailById(id)));
     }
@@ -60,7 +61,7 @@ public class HealthInfoApiController {
      */
     @SwaggerApi(summary = "특정 병과의 건강 정보 목록 페이징 조회", implementation = Page.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/health-infos")
+    @GetMapping
     public Page<HealthInfoDto> healthInfosByDepartmentUsingPaging(
             @RequestParam(name = "dept", required = false) final List<String> deptNumberList, final Pageable pageable) {
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/hospital/web/HospitalApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/hospital/web/HospitalApiController.java
@@ -25,13 +25,14 @@ import java.util.stream.Collectors;
 
 @Tag(name = "병원정보")
 @RestController
+@RequestMapping("/api/hospitals")
 @RequiredArgsConstructor
 public class HospitalApiController {
 
     private final HospitalService hospitalService;
 
     /* 병원 저장 */
-    @PostMapping("/api/hospitals")
+    @PostMapping
     public CreateHospitalResponse createHospitalRequest(
             @RequestBody @Valid final CreateHospitalRequest request) {
 
@@ -42,7 +43,7 @@ public class HospitalApiController {
 
 
     /* 병원 단건 조회 */
-    @GetMapping("/api/hospitals/{id}/details")
+    @GetMapping("/{id}/details")
     public Result hospital(@PathVariable final Long id) {
         return new Result(new HospitalDto(hospitalService.findById(id)));
     }
@@ -50,7 +51,7 @@ public class HospitalApiController {
 
     @SwaggerApi(summary = "병원 목록 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/hospitals")
+    @GetMapping
     public Result hospitals() {
         return new Result(hospitalService.findAll()
                 .stream().map(HospitalDto::new)
@@ -60,7 +61,7 @@ public class HospitalApiController {
     /**
      *  Open API를 이용해 공공데이터 가져오기
      */
-    @GetMapping("/api/hospinfo")
+    @GetMapping("/hospinfo")
     public String getHospitalInfo() throws IOException {
 
         /**
@@ -69,31 +70,31 @@ public class HospitalApiController {
          * https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15001698
          */
 
-        String baseURL = "https://apis.data.go.kr/B551182/hospInfoServicev2/getHospBasisList";
+        final String baseURL = "https://apis.data.go.kr/B551182/hospInfoServicev2/getHospBasisList";
 
-        String secretKey = "?ServiceKey=" + OpenAPIConfig.OpenAPISecretKey;
+        final String secretKey = "?ServiceKey=" + OpenAPIConfig.OpenAPISecretKey;
 //        String pageNo = "&pageNo=1";
 //        String sidoCd = "&sidoCd=250000";
-        String apiURL = baseURL + secretKey;
+        final String apiURL = baseURL + secretKey;
 
         /**
          * GET방식으로 전송해서 파라미터 받아오기
          */
-        URL url = new URL(apiURL);
+        final URL url = new URL(apiURL);
 
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("GET");
         conn.setRequestProperty("Content-type", "application/json");
 
 
-        BufferedReader rd;
+        final BufferedReader rd;
         if (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
             rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
         } else {
             rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
         }
 
-        StringBuilder sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder();
         String line;
 
         while ((line = rd.readLine()) != null) {

--- a/src/main/java/io/wisoft/capstonedesign/domain/hospital/web/ReadHospitalInfoController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/hospital/web/ReadHospitalInfoController.java
@@ -17,25 +17,25 @@ public class ReadHospitalInfoController {
     public Map<String, Object> readHospitalInfo() {
         Map<String, Object> map = new HashMap<>();
 
-        String baseURL = "https://apis.data.go.kr/B551182/hospInfoServicev2/getHospBasisList";
+        final String baseURL = "https://apis.data.go.kr/B551182/hospInfoServicev2/getHospBasisList";
 
-        String secretKey = "?ServiceKey=" + OpenAPIConfig.OpenAPISecretKey;
+        final String secretKey = "?ServiceKey=" + OpenAPIConfig.OpenAPISecretKey;
 //        String pageNo = "&pageNo=1";
 //        String sidoCd = "&sidoCd=250000";
-        String apiURL = baseURL + secretKey;
+        final String apiURL = baseURL + secretKey;
 
         try {
 
-            RestTemplate restTemplate = new RestTemplate();
+            final RestTemplate restTemplate = new RestTemplate();
 
             //1. API를 호출하여 결과를 가져오기
-            String response = restTemplate.getForObject(apiURL, String.class);
+            final String response = restTemplate.getForObject(apiURL, String.class);
 
             //2. 가공된 데이터를 반환
             System.out.println(response);
 
             //3. DB에 저장
-            JSONObject jsonObject = new JSONObject(response.toString());
+            final JSONObject jsonObject = new JSONObject(response.toString());
 //            JSONObject jsonObject = new JSONObject(response);
 
             System.out.println(jsonObject);

--- a/src/main/java/io/wisoft/capstonedesign/domain/member/web/MemberApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/member/web/MemberApiController.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 @Tag(name = "회원")
 @RestController
+@RequestMapping("/api/members")
 @RequiredArgsConstructor
 public class MemberApiController {
 
@@ -21,14 +22,14 @@ public class MemberApiController {
 
     @SwaggerApi(summary = "회원 단건 조회", implementation = Result.class)
     @SwaggerApiFailWithAuth
-    @GetMapping("/api/members/{id}/details")
+    @GetMapping("/{id}/details")
     public Result member(@PathVariable("id") final Long id) {
         return new Result(new MemberDto(memberService.findDetailById(id)));
     }
 
     @SwaggerApi(summary = "회원 목록 조회", implementation = Result.class)
     @SwaggerApiFailWithAuth
-    @GetMapping("/api/members")
+    @GetMapping
     public Result members() {
         return new Result(memberService.findAll().stream()
                 .map(MemberListDto::new)
@@ -38,7 +39,7 @@ public class MemberApiController {
 
     @SwaggerApi(summary = "회원 비밀번호 변경", implementation = UpdateMemberResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/members/{id}/password")
+    @PatchMapping("/{id}/password")
     public UpdateMemberResponse updateMemberPassword(
             @PathVariable("id") final Long id,
             @RequestBody @Valid final UpdateMemberPasswordRequest request) {
@@ -52,7 +53,7 @@ public class MemberApiController {
 
     @SwaggerApi(summary = "회원 정보 수정", implementation = UpdateMemberResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/members/{id}")
+    @PatchMapping("/{id}")
     public UpdateMemberResponse updateMember(
             @PathVariable("id") final Long id,
             @RequestParam(value = "photoPath", required = false) final String photoPath,
@@ -68,7 +69,7 @@ public class MemberApiController {
 
     @SwaggerApi(summary = "회원 탈퇴", implementation = DeleteMemberResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/members/{id}")
+    @DeleteMapping("/{id}")
     public DeleteMemberResponse deleteMember(@PathVariable("id") final Long id) {
         memberService.deleteMember(id);
         return new DeleteMemberResponse(id);

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
@@ -17,16 +17,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.*;
 import java.util.Map;
 
 @Slf4j
 @Controller //TODO : 나중에 프론트와 연동시 RestController 로 바꿀것
+@RequestMapping("/payment")
 @RequiredArgsConstructor
 public class PaymentController {
 
@@ -39,13 +37,13 @@ public class PaymentController {
     @Value("${iamport.api-secret}")
     private String API_SECRET;
 
-    @GetMapping("/payment")
+    @GetMapping
     public String payment() {
         return "payment";
     }
 
 
-    @PostMapping("/payment/{id}")
+    @PostMapping("/{id}")
     public ResponseEntity<?> savePayment(
             @RequestBody final Map<String, Object> model,
             @PathVariable(value = "id") final Long id) {

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
@@ -93,9 +93,9 @@ public class PaymentController {
 
     private void printModel(final String imp_uid, final String merchant_uid, final boolean success) {
         log.info("-----payment callback received-----");
-        log.info("imp_uid = " + imp_uid);
-        log.info("merchant_uid = " + merchant_uid);
-        log.info("success = " + success);
+        log.info("imp_uid = {}", imp_uid);
+        log.info("merchant_uid = {} ", merchant_uid);
+        log.info("success = {}", success);
     }
 
     private HttpHeaders makeHttpHeader() {

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/web/PaymentController.java
@@ -15,11 +15,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.*;
+import java.util.Collections;
 import java.util.Map;
 
 @Slf4j
@@ -99,6 +101,7 @@ public class PaymentController {
     private HttpHeaders makeHttpHeader() {
         final HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.add("Content-Type", "application/json; charset=UTF-8");
+        responseHeaders.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         return responseHeaders;
     }
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/web/RefundController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/web/RefundController.java
@@ -13,6 +13,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 @RestController
+@RequestMapping("/payment")
 @RequiredArgsConstructor
 public class RefundController {
 
@@ -24,7 +25,7 @@ public class RefundController {
     private final String GET_TOKEN_URL = "https://api.iamport.kr/users/getToken";
 
 
-    @GetMapping("/payment/token")
+    @GetMapping("/token")
     public ResponseEntity<String> getToken() throws IOException, JSONException {
 
         final HttpURLConnection conn = getTokenConnection();

--- a/src/main/java/io/wisoft/capstonedesign/domain/pick/web/PickApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/pick/web/PickApiController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "찜하기")
 @RestController
+@RequestMapping("/api/picks")
 @RequiredArgsConstructor
 public class PickApiController {
 
@@ -19,7 +20,7 @@ public class PickApiController {
 
     @SwaggerApi(summary = "찜하기 생성", implementation = CreatePickResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/picks")
+    @PostMapping
     public CreatePickResponse createPick(@RequestBody @Valid final CreatePickRequest request) {
         return new CreatePickResponse(pickService.save(request));
     }
@@ -27,7 +28,7 @@ public class PickApiController {
 
     @SwaggerApi(summary = "찜하기 취소", implementation = DeletePickResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/picks/{id}")
+    @DeleteMapping("/{id}")
     public DeletePickResponse deletePick(@PathVariable("id") final Long id) {
         pickService.cancelPick(id);
         return new DeletePickResponse(id);
@@ -36,7 +37,7 @@ public class PickApiController {
 
     @SwaggerApi(summary = "찜하기 단건 상세 조회", implementation = Result.class)
     @SwaggerApiFailWithAuth
-    @GetMapping("/api/picks/{id}/details")
+    @GetMapping("/{id}/details")
     public Result pick(@PathVariable("id") final Long id) {
         return new Result(new PickDto(pickService.findDetailById(id)));
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/review/web/ReviewApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/review/web/ReviewApiController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "리뷰")
 @RestController
+@RequestMapping("/api/reviews")
 @RequiredArgsConstructor
 public class ReviewApiController {
 
@@ -23,7 +24,7 @@ public class ReviewApiController {
 
     @SwaggerApi(summary = "리뷰 단건 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/reviews/{id}/details")
+    @GetMapping("/{id}/details")
     public Result review(@PathVariable("id") final Long id) {
         return new Result(new ReviewDto(reviewService.findDetailById(id)));
     }
@@ -31,7 +32,7 @@ public class ReviewApiController {
 
     @SwaggerApi(summary = "리뷰 목록 페이징 조회", implementation = Page.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/reviews")
+    @GetMapping
     public Page<ReviewListDto> reviewsUsingPaging(final Pageable pageable) {
         return reviewService.findByUsingPaging(pageable).map(ReviewListDto::new);
     }
@@ -39,7 +40,7 @@ public class ReviewApiController {
 
     @SwaggerApi(summary = "특정 병원의 리뷰 목록 페이징 조회", implementation = Page.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/reviews/hospital")
+    @GetMapping("/hospital")
     public Page<ReviewListDto> reviewsByTargetHospital(
             @RequestBody @Valid final ReviewsByTargetHospitalRequest request,
             final Pageable pageable) {
@@ -51,7 +52,7 @@ public class ReviewApiController {
 
     @SwaggerApi(summary = "리뷰 저장", implementation = CreateReviewResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/reviews")
+    @PostMapping
     public CreateReviewResponse createReview(
             @RequestBody @Valid final CreateReviewRequest request) {
 
@@ -64,7 +65,7 @@ public class ReviewApiController {
 
     @SwaggerApi(summary = "리뷰 수정", implementation = UpdateReviewResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/reviews/{id}")
+    @PatchMapping("/{id}")
     public UpdateReviewResponse updateReview(
             @PathVariable("id") final Long id,
             @RequestBody @Valid final UpdateReviewRequest request) {
@@ -78,7 +79,7 @@ public class ReviewApiController {
 
     @SwaggerApi(summary = "리뷰 삭제", implementation = DeleteReviewResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/reviews/{id}")
+    @DeleteMapping("/{id}")
     public DeleteReviewResponse deleteReview(@PathVariable("id") final Long id) {
 
         reviewService.deleteReview(id);

--- a/src/main/java/io/wisoft/capstonedesign/domain/reviewreply/web/ReviewReplyApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/reviewreply/web/ReviewReplyApiController.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 @Tag(name = "리뷰 댓글")
 @RestController
+@RequestMapping("/api/review-reply")
 @RequiredArgsConstructor
 public class ReviewReplyApiController {
 
@@ -23,7 +24,7 @@ public class ReviewReplyApiController {
 
     @SwaggerApi(summary = "리뷰댓글 저장", implementation = CreateReviewReplyResponse.class)
     @SwaggerApiFailWithAuth
-    @PostMapping("/api/review-reply")
+    @PostMapping
     public CreateReviewReplyResponse createReviewReply(
             @RequestBody @Valid final CreateReviewReplyRequest request) {
 
@@ -35,7 +36,7 @@ public class ReviewReplyApiController {
 
     @SwaggerApi(summary = "리뷰댓글 삭제", implementation = DeleteReviewReplyResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("/api/review-reply/{id}")
+    @DeleteMapping("/{id}")
     public DeleteReviewReplyResponse deleteReviewReply(
             @PathVariable("id") final Long id) {
 
@@ -46,7 +47,7 @@ public class ReviewReplyApiController {
 
     @SwaggerApi(summary = "리뷰댓글 수정", implementation = UpdateReviewReplyResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/review-reply/{id}")
+    @PatchMapping("/{id}")
     public UpdateReviewReplyResponse updateReviewReply(
             @PathVariable("id") final Long id,
             @RequestBody @Valid final UpdateReviewReplyRequest request) {
@@ -59,7 +60,7 @@ public class ReviewReplyApiController {
 
     @SwaggerApi(summary = "리뷰댓글 단건 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/review-reply/{id}/details")
+    @GetMapping("/{id}/details")
     public Result reviewReply(@PathVariable("id") final Long id) {
         return new Result(new ReviewReplyDto(reviewReplyService.findDetailById(id)));
     }
@@ -67,7 +68,7 @@ public class ReviewReplyApiController {
 
     @SwaggerApi(summary = "특정 리뷰의 댓글목록 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/review-reply/review/{review-id}")
+    @GetMapping("/review/{review-id}")
     public Result reviewReplyByReview(
             @PathVariable("review-id") final Long reviewId) {
 
@@ -80,7 +81,7 @@ public class ReviewReplyApiController {
     @SwaggerApi(summary = "특정 리뷰의 댓글목록 오름차순 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
 
-    @GetMapping("/api/review-reply/review/{review-id}/create-asc")
+    @GetMapping("/review/{review-id}/create-asc")
     public Result reviewReplyByReviewOrderByCreateAsc(
             @PathVariable("review-id") final Long reviewId) {
 
@@ -92,7 +93,7 @@ public class ReviewReplyApiController {
 
     @SwaggerApi(summary = "특정 리뷰의 댓글목록 내림차순 조회", implementation = Result.class)
     @SwaggerApiFailWithoutAuth
-    @GetMapping("/api/review-reply/review/{review-id}/create-desc")
+    @GetMapping("/review/{review-id}/create-desc")
     public Result reviewReplyByReviewOrderByCreateDesc(
             @PathVariable("review-id") final Long reviewId) {
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/staff/web/StaffApiController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/staff/web/StaffApiController.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 @Tag(name = "의료진")
 @RestController
+@RequestMapping("/api/staff")
 @RequiredArgsConstructor
 public class StaffApiController {
 
@@ -21,14 +22,14 @@ public class StaffApiController {
 
     @SwaggerApi(summary = "의료진 단건 상세 조회", implementation = Result.class)
     @SwaggerApiFailWithAuth
-    @GetMapping("api/staff/{id}/details")
+    @GetMapping("/{id}/details")
     public Result staff(@PathVariable("id") final Long id) {
         return new Result(new StaffDto(staffService.findDetailById(id)));
     }
 
     @SwaggerApi(summary = "의료진 목록 조회", implementation = Result.class)
     @SwaggerApiFailWithAuth
-    @GetMapping("/api/staff")
+    @GetMapping
     public Result staffs() {
 
         return new Result(staffService.findAllByHospital().stream()
@@ -39,7 +40,7 @@ public class StaffApiController {
 
     @SwaggerApi(summary = "의료진 비밀번호 변경", implementation = UpdateStaffResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/staff/{id}/password")
+    @PatchMapping("/{id}/password")
     public UpdateStaffResponse updateStaffPassword(
             @PathVariable("id") final Long id,
             @RequestBody @Valid final UpdateStaffPasswordRequest request) {
@@ -53,7 +54,7 @@ public class StaffApiController {
 
     @SwaggerApi(summary = "의료진 정보 수정", implementation = UpdateStaffResponse.class)
     @SwaggerApiFailWithAuth
-    @PatchMapping("/api/staff/{id}")
+    @PatchMapping("/{id}")
     public UpdateStaffResponse updateStaff(
             @PathVariable("id") final Long id,
             @RequestParam(value = "hospitalName", required = false) final String hospitalName,
@@ -68,7 +69,7 @@ public class StaffApiController {
 
     @SwaggerApi(summary = "의료진 탈퇴", implementation = DeleteStaffResponse.class)
     @SwaggerApiFailWithAuth
-    @DeleteMapping("api/staff/{id}")
+    @DeleteMapping("/{id}")
     public DeleteStaffResponse deleteStaff(@PathVariable("id") final Long id) {
 
         staffService.deleteStaff(id);

--- a/src/main/java/io/wisoft/capstonedesign/global/jwt/RedisJwtBlackList.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/jwt/RedisJwtBlackList.java
@@ -24,7 +24,7 @@ public class RedisJwtBlackList {
         }
 
         redisTemplate.opsForValue().set(jwt, "blacklisted", TIME_OUT, TimeUnit.SECONDS);
-        log.info("redis : 토큰 (" + jwt + ")을 로그아웃 처리합니다.");
+        log.info("redis : 토큰 {}을 로그아웃 처리합니다.", jwt);
     }
 
     private boolean isContained(final String jwt) {


### PR DESCRIPTION
## What is this PR? 📍
결제 취소 API를 개발합니다.
해당 API로 요청이 들어오면 헤더로부터 토큰을 추출하고,
해당 토큰을 이용해 iamport의 결제 취소 API를 RestTemplate를 이용해 호출합니다.

결제 과정 이후, 엔티티 생성 과정 및 상태 변경 과정에서 오류가 발생한다면?
결제 취소가 자동적으로 이루어져야 합니다. 따라서 예외가 발생시 결제취소가 이루어지도록 설계하였습니다.

<br/>

## Changes 🔍


<br/>
 
## Todo 🗓️

<br/>