### PR TITLE
feat :  서버 장애 모니터링을 위한 Slack 챗봇 연동하기(#167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ h2
 *application-openapi.yml*
 *application-iamport.yml*
 *application-redis.yml*
+*application-slack.yml*
 docker-compose.yml
 *a_test*
 *templates*

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.0.2'
-	id 'io.spring.dependency-management' version '1.1.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.0.2'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'io.wisoft'
@@ -9,74 +9,79 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	maven { url 'https://jitpack.io' }
-	mavenCentral()
+    maven { url 'https://jitpack.io' }
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-devtools'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
-	//jbcrypt
-	implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.4'
+    //slack
+    implementation("com.slack.api:bolt:1.18.0")
+    implementation("com.slack.api:bolt-servlet:1.18.0")
+    implementation("com.slack.api:bolt-jetty:1.18.0")
 
-	//activation-api와 충돌을 피하기 위해 제거
-	implementation('javax.xml.bind:jaxb-api:2.3.1') {
-		exclude group: 'jakarta.activation', module: 'jakarta.activation-api'
-	}
+    //jbcrypt
+    implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.4'
 
-	//jwt
-	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    //activation-api와 충돌을 피하기 위해 제거
+    implementation('javax.xml.bind:jaxb-api:2.3.1') {
+        exclude group: 'jakarta.activation', module: 'jakarta.activation-api'
+    }
 
-	//postgreSQL
-	implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.1'
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
-	//java mail
-	implementation 'jakarta.activation:jakarta.activation-api'
-	implementation ('org.springframework.boot:spring-boot-starter-mail') {
-		exclude group: 'com.sun.activation', module: 'javax.activation'
-	}
+    //postgreSQL
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.1'
 
-	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    //java mail
+    implementation 'jakarta.activation:jakarta.activation-api'
+    implementation('org.springframework.boot:spring-boot-starter-mail') {
+        exclude group: 'com.sun.activation', module: 'javax.activation'
+    }
 
-	//JSONObject
-	implementation group: 'org.json', name: 'json', version: '20090211'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
-	//Thymeleaf - 프론트 화면을 임시 대체
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    //JSONObject
+    implementation group: 'org.json', name: 'json', version: '20090211'
 
-	//iamport
-	implementation 'com.github.iamport:iamport-rest-client-java:0.2.22'
+    //Thymeleaf - 프론트 화면을 임시 대체
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-	//redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //iamport
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.22'
 
-	//E2E test를 위한 의존성
-	testImplementation 'io.rest-assured:rest-assured'
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //E2E test를 위한 의존성
+    testImplementation 'io.rest-assured:rest-assured'
 
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	//JUnit4 추가
-	testImplementation("org.junit.vintage:junit-vintage-engine") {
-		exclude group: "org.hamcrest", module: "hamcrest-core"
-	}
+    //JUnit4 추가
+    testImplementation("org.junit.vintage:junit-vintage-engine") {
+        exclude group: "org.hamcrest", module: "hamcrest-core"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/web/RefundController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/web/RefundController.java
@@ -81,7 +81,7 @@ public class RefundController {
         executePaymentCancel(token, merchantUid, appointmentId);
     }
 
-    private ResponseEntity<String> executePaymentCancel(String token, String merchantUid, Long appointmentId) {
+    private ResponseEntity<String> executePaymentCancel(final String token, final String merchantUid, final Long appointmentId) {
         final HttpHeaders headers = getHttpHeaders(token);
 
         final JSONObject jsonObject = getJsonObject(merchantUid);
@@ -96,7 +96,7 @@ public class RefundController {
 
 
     @NotNull
-    private ResponseEntity<String> sendCancelRequest(HttpHeaders headers, JSONObject jsonObject) {
+    private ResponseEntity<String> sendCancelRequest(final HttpHeaders headers, final JSONObject jsonObject) {
         final RestTemplate restTemplate = new RestTemplate();
         final HttpEntity<String> entity = new HttpEntity<>(jsonObject.toString(), headers);
         return restTemplate.exchange(

--- a/src/main/java/io/wisoft/capstonedesign/global/config/WebMvcConfig.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/config/WebMvcConfig.java
@@ -36,6 +36,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/search")
 
                 .addPathPatterns("/api/auth/logout")
+                .addPathPatterns("/jwt/re-issuance")
 
                 .addPathPatterns("/api/members")
                 .addPathPatterns("/api/members/**") //마이페이지가 여기에 같이 포함
@@ -72,6 +73,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/bus-info/**")
                 .excludePathPatterns("/api/bus-info/{id}/details")
                 .excludePathPatterns("/api/bus-info/area/{area}/details")
+
+                .addPathPatterns("/payment")
+                .addPathPatterns("/payment/**")
 
         ;
 

--- a/src/main/java/io/wisoft/capstonedesign/global/slack/SlackConstant.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/slack/SlackConstant.java
@@ -1,0 +1,20 @@
+package io.wisoft.capstonedesign.global.slack;
+
+
+public enum SlackConstant {
+
+    //slack 채널명
+    ERROR_CHANNEL("#장애확인"),
+    TALKING_CHANNEL("#잡담"),
+    ANNOUNCEMENT_CHANNEL("#공지");
+
+    private String channel;
+
+    SlackConstant(final String channel) {
+        this.channel = channel;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+}

--- a/src/main/java/io/wisoft/capstonedesign/global/slack/SlackErrorMessage.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/slack/SlackErrorMessage.java
@@ -1,0 +1,13 @@
+package io.wisoft.capstonedesign.global.slack;
+
+import java.time.LocalDateTime;
+
+public record SlackErrorMessage(LocalDateTime dateTime, String message) {
+
+    @Override
+    public String toString() {
+        return  "장애 발생! 🔥" +
+                "\n에러 발생 일시 = " + dateTime +
+                "\n에러 메시지 = " + message;
+    }
+}

--- a/src/main/java/io/wisoft/capstonedesign/global/slack/SlackService.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/slack/SlackService.java
@@ -1,0 +1,37 @@
+package io.wisoft.capstonedesign.global.slack;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+public class SlackService {
+
+    @Value(value = "${slack.token}")
+    private String slackToken;
+
+    public void sendSlackMessage(final SlackErrorMessage message, final SlackConstant slackConstant) {
+
+        final String channel = slackConstant.getChannel();
+
+        try {
+            final MethodsClient slackBot = Slack.getInstance().methods(slackToken);
+
+            final ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                    .channel(channel)
+                    .text(message.toString())
+                    .build();
+
+            slackBot.chatPostMessage(request);
+        } catch (SlackApiException | IOException e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/domain/appointment/persistence/AppointmentTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/appointment/persistence/AppointmentTest.java
@@ -3,6 +3,7 @@ package io.wisoft.capstonedesign.domain.appointment.persistence;
 import io.wisoft.capstonedesign.domain.hospital.persistence.Hospital;
 import io.wisoft.capstonedesign.domain.member.persistence.Member;
 import io.wisoft.capstonedesign.global.enumeration.HospitalDept;
+import io.wisoft.capstonedesign.global.enumeration.status.PayStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -49,6 +50,7 @@ class AppointmentTest {
                 .comment("comment")
                 .appointName("appointmentName")
                 .appointPhonenumber("appointPhonenumber")
+                .payStatus(PayStatus.NONE)
                 .build();
     }
 

--- a/src/test/java/io/wisoft/capstonedesign/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/auth/application/AuthServiceTest.java
@@ -63,10 +63,11 @@ public class AuthServiceTest extends ServiceTest {
 
         //when -- 동작
         final LoginRequest loginRequest = new LoginRequest(request.email(), request.password1());
-        final String token = authService.loginMember(loginRequest);
+        final TokenResponse tokenResponse = authService.loginMember(loginRequest);
 
         //then -- 검증
-        Assertions.assertThat(token).isNotNull();
+        Assertions.assertThat(tokenResponse.accessToken()).isNotNull();
+        Assertions.assertThat(tokenResponse.refreshToken()).isNotNull();
     }
 
 
@@ -117,10 +118,11 @@ public class AuthServiceTest extends ServiceTest {
 
         //when -- 동작
         final LoginRequest loginRequest = new LoginRequest(request.email(), request.password1());
-        final String token = authService.loginStaff(loginRequest);
+        final TokenResponse tokenResponse = authService.loginStaff(loginRequest);
 
         //then -- 검증
-        Assertions.assertThat(token).isNotNull();
+        Assertions.assertThat(tokenResponse.accessToken()).isNotNull();
+        Assertions.assertThat(tokenResponse.refreshToken()).isNotNull();
     }
 
 
@@ -145,8 +147,8 @@ public class AuthServiceTest extends ServiceTest {
         //when -- 동작
         //then -- 검증
         assertThrows(IllegalValueException.class, () -> {
-            LoginRequest loginRequest = new LoginRequest(request.email(), "fail-password");
-            String token = authService.loginStaff(loginRequest);
+            final LoginRequest loginRequest = new LoginRequest(request.email(), "fail-password");
+            authService.loginStaff(loginRequest);
         });
     }
 

--- a/src/test/java/io/wisoft/capstonedesign/domain/boardreply/persistence/BoardReplyRepositoryTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/boardreply/persistence/BoardReplyRepositoryTest.java
@@ -25,6 +25,6 @@ public class BoardReplyRepositoryTest {
         final List<BoardReply> list = boardReplyRepository.findByBoardIdOrderByCreateAsc(boardId);
 
         //then -- 검증
-        Assertions.assertThat(list.size()).isEqualTo(5);
+        Assertions.assertThat(list.size()).isEqualTo(2);
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/domain/review/application/ReviewServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/review/application/ReviewServiceTest.java
@@ -185,7 +185,7 @@ public class ReviewServiceTest extends ServiceTest {
 
         //when -- 동작
         //then -- 검증
-        assertThrows(IllegalValueException.class, () -> {
+        assertThrows(NotFoundException.class, () -> {
             reviewService.findByTargetHospital("아보카두두병원", request);
         });
     }

--- a/src/test/java/io/wisoft/capstonedesign/domain/review/persistence/ReviewRepositoryTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/review/persistence/ReviewRepositoryTest.java
@@ -1,6 +1,5 @@
 package io.wisoft.capstonedesign.domain.review.persistence;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/io/wisoft/capstonedesign/domain/reviewreply/application/ReviewReplyServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/reviewreply/application/ReviewReplyServiceTest.java
@@ -137,7 +137,7 @@ public class ReviewReplyServiceTest extends ServiceTest {
 
         final CreateReviewReplyRequest request = getCreateReviewReplyRequest(member, review, "저도 가봐야겠네요");
 
-        final Long saveId = reviewReplyService.save(request);
+        reviewReplyService.save(request);
 
         //when -- 동작
         //then -- 검증

--- a/src/test/java/io/wisoft/capstonedesign/domain/staff/application/StaffServiceTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/staff/application/StaffServiceTest.java
@@ -67,13 +67,13 @@ public class StaffServiceTest extends ServiceTest {
         //의료진 가입 요청
         final CreateStaffRequest request = getCreateStaffRequest(email, hospital);
 
-        final Long signUpId = authService.signUpStaff(request);
+        authService.signUpStaff(request);
 
 
         //when -- 동작
         //then -- 검증
         assertThrows(NotFoundException.class, () -> {
-            Staff staff = staffService.findById(100L);
+            staffService.findById(100L);
         });
     }
 

--- a/src/test/java/io/wisoft/capstonedesign/global/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/global/jwt/JwtTokenProviderTest.java
@@ -1,12 +1,16 @@
 package io.wisoft.capstonedesign.global.jwt;
 
+import io.wisoft.capstonedesign.global.exception.token.InvalidTokenException;
 import io.wisoft.capstonedesign.global.exception.token.NotExistTokenException;
+import io.wisoft.capstonedesign.global.redis.RedisAdapter;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,28 +20,42 @@ public class JwtTokenProviderTest {
 
     @Autowired JwtTokenProvider jwtTokenProvider;
     @Autowired RedisJwtBlackList redisJwtBlackList;
-    @Autowired private StringRedisTemplate stringRedisTemplate;
+    @Autowired RedisAdapter redisAdapter;
 
     @Test
-    public void createToken_success() throws Exception {
+    public void createAccessToken_success() throws Exception {
         //given -- 조건
-        String subject = "test-token-subject";
+        final String subject = "test-subject";
 
         //when -- 동작
-        String token = jwtTokenProvider.createAccessToken(subject);
+        final String token = jwtTokenProvider.createAccessToken(subject);
 
         //then -- 검증
         Assertions.assertThat(token).isNotNull();
     }
 
+
+    @Test
+    public void createRefreshToken_success() throws Exception {
+        //given -- 조건
+        final String subject = "test";
+
+        //when -- 동작
+        final String refreshToken = jwtTokenProvider.createRefreshToken(subject);
+
+        //then -- 검증
+        Assertions.assertThat(refreshToken).isNotNull();
+    }
+
+
     @Test
     public void getSubject_success() throws Exception {
         //given -- 조건
-        String subject = "test-token-subject";
-        String token = jwtTokenProvider.createAccessToken(subject);
+        final String subject = "test-token-subject";
+        final String token = jwtTokenProvider.createAccessToken(subject);
 
         //when -- 동작
-        String getSubject = jwtTokenProvider.getSubject(token);
+        final String getSubject = jwtTokenProvider.getSubject(token);
 
         //then -- 검증
         Assertions.assertThat(subject).isEqualTo(getSubject);
@@ -46,10 +64,10 @@ public class JwtTokenProviderTest {
     @Test
     public void validateToken_success() throws Exception {
         //given -- 조건
-        String subject = "test-token-subject";
-        String token = jwtTokenProvider.createAccessToken(subject);
+        final String subject = "subject";
+        final String token = jwtTokenProvider.createAccessToken(subject);
 
-        stringRedisTemplate.opsForValue().set(token, "123");
+        redisAdapter.setValue(subject, token, 1200000, TimeUnit.SECONDS);
 
         //when -- 동작
         boolean result = jwtTokenProvider.validateToken(token);
@@ -59,17 +77,18 @@ public class JwtTokenProviderTest {
     }
 
     @Test
+    @DisplayName("유효하지 않은 토큰이 요청 헤더에 들어온 경우")
     public void validateToken_fail() throws Exception {
         //given -- 조건
-        String subject = "test-token-subject";
-        String token = jwtTokenProvider.createAccessToken(subject);
+        final String subject = "email@email.com";
+        final String refreshToken = jwtTokenProvider.createRefreshToken(subject);
 
-        stringRedisTemplate.opsForValue().set(token, "123");
+        redisAdapter.setValue(subject, refreshToken, 1200000, TimeUnit.SECONDS);
 
         //when -- 동작
         //then -- 검증
-        assertThrows(NotExistTokenException.class, () -> {
-            boolean result = jwtTokenProvider.validateToken("not-valid-token");
+        assertThrows(InvalidTokenException.class, () -> {
+            jwtTokenProvider.validateToken("Invalid-token");
         });
     }
 }

--- a/src/test/java/io/wisoft/capstonedesign/setting/data/ReviewTestData.java
+++ b/src/test/java/io/wisoft/capstonedesign/setting/data/ReviewTestData.java
@@ -10,6 +10,7 @@ public class ReviewTestData {
                 .title("good")
                 .body("good hospital")
                 .starPoint(5)
+                .reviewPhotoPath("default-path")
                 .target_hospital("아보카도")
                 .build();
     }


### PR DESCRIPTION
## What is this PR? 📍
현재 프론트엔드 서버와 백엔드 서버와의 연동 과정에 있습니다.
프론트 서버에서 요청을 보냈지만, 백엔드 서버의 비즈니스 로직 실행 중에 예외가 발생하는 경우가 있지만
프론트엔드 담당은 어떤 예외가 발생했는지 등의 상황을 알기 힘들 때가 있습니다.

따라서 프로젝트에 Slack 챗봇을 연동하여, 백엔드 서버에서 예외 발생시 Slack을 통해 상황을 모니터링 할 수 있도록 합니다.

<img width="980" alt="스크린샷 2023-06-15 오후 4 32 43" src="https://github.com/HBNU-Avocado/Avocado-backend/assets/95692663/9ea576bb-bee2-4779-9beb-c9ea06706932">

<br/>

## Changes 🔍
예외 처리를 담당하는 `GlobalExceptionHandler`의 공통 처리 로직에 Slack 메시지 송신 기능을 추가하였습니다.


<br/>
 
## Todo 🗓️

<br/>