### PR TITLE
fix : 로그아웃 로직 수정(#117)

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/web/AuthController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/web/AuthController.java
@@ -15,6 +15,7 @@ import io.wisoft.capstonedesign.global.annotation.swagger.SwaggerApiFailWithoutA
 import io.wisoft.capstonedesign.global.exception.ErrorCode;
 import io.wisoft.capstonedesign.global.exception.illegal.IllegalValueException;
 import io.wisoft.capstonedesign.global.jwt.AuthorizationExtractor;
+import io.wisoft.capstonedesign.global.jwt.JwtTokenProvider;
 import io.wisoft.capstonedesign.global.jwt.RedisJwtBlackList;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
     private final AuthorizationExtractor authExtractor;
     private final RedisJwtBlackList redisJwtBlackList;
 
@@ -63,14 +65,14 @@ public class AuthController {
     @SwaggerApi(summary = "로그아웃", implementation = ResponseEntity.class)
     @SwaggerApiFailWithAuth
     @PostMapping("/logout")
-    public ResponseEntity<String> logoutMember(HttpServletRequest request) throws IllegalAccessException {
+    public ResponseEntity<String> logoutMember(final HttpServletRequest request) {
 
-        final String token = authExtractor.extract(request, "Bearer");
-        redisJwtBlackList.addToBlackList(token);
+        final String accessToken = authExtractor.extract(request, "Bearer");
+        final String email = jwtTokenProvider.getSubject(accessToken);
+        redisJwtBlackList.addToBlackList(email);
 
         return ResponseEntity.ok("logout success");
     }
-
 
     @SwaggerApi(summary = "의료진 가입", implementation = CreateStaffResponse.class)
     @SwaggerApiFailWithoutAuth

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorCode.java
@@ -31,7 +31,9 @@ public enum ErrorCode {
     ILLEGAL_STAR_POINT(400, "Illegal-StarPoint-400", "StarPoint between 1 and 5"),
     INVALID_TOKEN(403, "Illegal-Invalid-Token-401", "Token is invalid"),
     NOT_EXIST_TOKEN(401, "Illegal-Not-Exist-Token-401", "Token is not exist"),
-    EXPIRED_TOKEN(401, "Illegal-Expired-Token-401", "Token is expired");
+    EXPIRED_TOKEN(401, "Illegal-Expired-Token-401", "Token is expired"),
+    ALREADY_LOGOUT_TOKEN(403, "Token-403", "Already logout token"),
+    JWT_EXCEPTION(400, "Token-400", "JWT is invalid");
 
 
     private int httpStatusCode;

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package io.wisoft.capstonedesign.global.exception;
 
+import io.jsonwebtoken.JwtException;
 import io.wisoft.capstonedesign.global.exception.duplicate.DuplicateEmailException;
 import io.wisoft.capstonedesign.global.exception.duplicate.DuplicateHospitalException;
 import io.wisoft.capstonedesign.global.exception.duplicate.DuplicateNicknameException;
 import io.wisoft.capstonedesign.global.exception.illegal.IllegalValueException;
 import io.wisoft.capstonedesign.global.exception.notfound.NotFoundException;
+import io.wisoft.capstonedesign.global.exception.token.AlreadyLogoutException;
 import io.wisoft.capstonedesign.global.exception.token.ExpiredTokenException;
 import io.wisoft.capstonedesign.global.exception.token.InvalidTokenException;
 import io.wisoft.capstonedesign.global.exception.token.NotExistTokenException;
@@ -99,6 +101,28 @@ public class GlobalExceptionHandler {
 
         log.error("handleInvalidTokenException", exception);
         return getErrorResponseResponseEntity(exception.getErrorCode());
+    }
+
+
+    /**
+     * 로그아웃된 토큰으로 요청할 경우
+     */
+    @ExceptionHandler(AlreadyLogoutException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyLogoutException(final AlreadyLogoutException exception) {
+
+        log.error("handleAlreadyLogoutException", exception);
+        return getErrorResponseResponseEntity(exception.getErrorCode());
+    }
+
+
+    /**
+     * JWT exception
+     */
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<ErrorResponse> handleJwtException(final JwtException exception) {
+
+        log.error("handleJwtException", exception);
+        return getErrorResponseResponseEntity(ErrorCode.JWT_EXCEPTION);
     }
 
 

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/token/AlreadyLogoutException.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/token/AlreadyLogoutException.java
@@ -1,0 +1,15 @@
+package io.wisoft.capstonedesign.global.exception.token;
+
+import io.wisoft.capstonedesign.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AlreadyLogoutException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AlreadyLogoutException(final String message, final ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/io/wisoft/capstonedesign/global/interceptor/BearerAuthInterceptor.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/interceptor/BearerAuthInterceptor.java
@@ -33,17 +33,17 @@ public class BearerAuthInterceptor implements HandlerInterceptor {
 
         logger.info("interceptor.preHandle 호출");
 
-        final String token = authExtractor.extract(request, "Bearer");
+        final String accessToken = authExtractor.extract(request, "Bearer");
 
-        if (!StringUtils.hasText(token)) {
+        if (!StringUtils.hasText(accessToken)) {
             logger.error("토큰이 적재되지 않음");
             throw new NotExistTokenException("토큰이 적재되지 않음", ErrorCode.NOT_EXIST_TOKEN);
         }
 
-        jwtTokenProvider.validateToken(token);
-
         //토큰을 디코딩
-        final String email = jwtTokenProvider.getSubject(token);
+        final String email = jwtTokenProvider.getSubject(accessToken);
+
+        jwtTokenProvider.validateToken(email);
 
         //디코딩한 값으로 세팅
         request.setAttribute("email", email);

--- a/src/main/java/io/wisoft/capstonedesign/global/jwt/RedisJwtBlackList.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/jwt/RedisJwtBlackList.java
@@ -16,17 +16,17 @@ public class RedisJwtBlackList {
     private final RedisAdapter redisAdapter;
     private final String LOGOUT_STATUS = "LOGOUT_STATUS";
 
-    public void addToBlackList(final String jwt) {
+    public void addToBlackList(final String email) {
 
-        if (isContained(jwt)) {
-            redisAdapter.deleteValue(jwt);
+        if (isContained(email)) {
+            redisAdapter.deleteValue(email);
         }
 
-        redisAdapter.setValue(jwt, LOGOUT_STATUS, TIME_OUT, TimeUnit.SECONDS);
-        log.info("redis : 토큰 {}을 로그아웃 처리합니다.", jwt);
+        redisAdapter.setValue(email, LOGOUT_STATUS, TIME_OUT, TimeUnit.SECONDS);
+        log.info("redis : {}을 로그아웃 처리합니다.", email);
     }
 
-    private boolean isContained(final String jwt) {
-        return redisAdapter.hasKey(jwt);
+    public boolean isContained(final String email) {
+        return redisAdapter.hasKey(email);
     }
 }


### PR DESCRIPTION
## What is this PR? 📍
로그아웃 로직을 수정합니다.

<br/>

## Changes 🔍
기존 방식
- 로그아웃을 요청한 토큰을 Redis에 Key로 잡고, 블랙리스트로 등록
- 이 방식의 경우 로그인 시에는 email을 key로, token을 value로 Redis에 저장하는데 이 과정에서 아래와 같은 번거로움이 생긴다.
  - 토큰이 유효한지 검사할 때는 Redis에서 key가 email인 값이 저장되어 있는지를 확인
  - 토큰이 로그아웃 처리된 토큰인지를 검사할 때는 Redis에 key가 token인 값이 있는지를 확인
  - 검사를 할 때마다 기준으로 잡은 key가 다르기 때문에 실수를 유발할 수 있다!

<br/>

수정 방식
- 로그인 시에는 기존과 같이 key를 email로, value를 token으로 잡고
- 로그아웃 시에 key를 위와같이 동일하게 email로 잡고, value를 `LOGOUT_STATUS` 라는 문자열로 지정한다.
  - 따라서 유효한 토큰인지 검사할 때는 key가 email과 일치하는 값이 저장되어 있는지만 확인하면 되고,
  - 로그아웃 처리된 토큰인지를 검사할 때는 Redis에서 key를 이용해 value를 조회하여, 로그아웃 문자열이 들어가있는지 확인하면 된다.


<br/>
 
## Todo 🗓️
