### PR TITLE
Test : 결제 취소 관련 테스트 작성 & Fix : 지난 코드 리뷰 반영

### DIFF
--- a/src/main/java/io/wisoft/capstonedesign/domain/appointment/application/AppointmentService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/appointment/application/AppointmentService.java
@@ -119,11 +119,13 @@ public class AppointmentService {
     /* 조회 로직 */
 
     public Appointment findDetailById(final Long appointmentId) {
-        return appointmentRepository.findDetailById(appointmentId).orElseThrow(NotFoundException::new);
+        return appointmentRepository.findDetailById(appointmentId)
+                .orElseThrow(() -> new NotFoundException("appointment 조회 실패"));
     }
 
     public Appointment findById(final Long appointmentId) {
-        return appointmentRepository.findById(appointmentId).orElseThrow(NotFoundException::new);
+        return appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new NotFoundException("appointment 조회 실패"));
     }
 }
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/application/AuthService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/application/AuthService.java
@@ -80,7 +80,7 @@ public class AuthService {
     public TokenResponse loginMember(final LoginRequest request) {
 
         final Member member = memberRepository.findMemberByEmail(request.email())
-                .orElseThrow(NotFoundException::new);
+                .orElseThrow(() -> new NotFoundException("회원 조회 실패"));
 
         validatePassword(request, member.getPassword());
 
@@ -125,7 +125,7 @@ public class AuthService {
     public TokenResponse loginStaff(final LoginRequest request) {
 
         final Staff staff = staffRepository.findStaffByEmail(request.email())
-                .orElseThrow(NotFoundException::new);
+                .orElseThrow(() -> new NotFoundException("의료진 조회 실패"));
 
         validatePassword(request, staff.getPassword());
 
@@ -154,7 +154,8 @@ public class AuthService {
     }
 
     private void validateEmailVerified(final String email) throws IllegalStateException {
-        final DBMailAuthentication mail = mailAuthenticationRepository.findByEmail(email).orElseThrow(NotFoundException::new);
+        final DBMailAuthentication mail = mailAuthenticationRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("이메일 인증 정보 조회 실패"));
 
         if (!mail.isVerified()) {
             throw new IllegalValueException("이메일 인증을 완료해주세요.", ErrorCode.ILLEGAL_STATE);

--- a/src/main/java/io/wisoft/capstonedesign/domain/auth/application/EmailServiceImpl.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/auth/application/EmailServiceImpl.java
@@ -109,7 +109,8 @@ public class EmailServiceImpl implements EmailService {
     @Async
     @Transactional
     public void sendResetMemberPassword(final String to) {
-        final Member member = memberRepository.findByEmail(to).orElseThrow(NotFoundException::new);
+        final Member member = memberRepository.findByEmail(to)
+                .orElseThrow(() -> new NotFoundException("회원 조회 실패"));
 
         final String resetPassword = createRandomCode();
         sendEmail(to, PASSWORD_RESET_SUBJECT, resetPassword);
@@ -122,7 +123,8 @@ public class EmailServiceImpl implements EmailService {
     @Async
     @Transactional
     public void sendResetStaffPassword(final String to) {
-        final Staff staff = staffRepository.findByEmail(to).orElseThrow(NotFoundException::new);
+        final Staff staff = staffRepository.findByEmail(to)
+                .orElseThrow(() -> new NotFoundException("의료진 조회 실패"));
 
         final String resetPassword = createRandomCode();
         sendEmail(to, PASSWORD_RESET_SUBJECT, resetPassword);

--- a/src/main/java/io/wisoft/capstonedesign/domain/board/application/BoardService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/board/application/BoardService.java
@@ -82,12 +82,14 @@ public class BoardService {
     /* 조회 로직 */
     /** 게시글 단건 상세 조회 */
     public Board findDetailById(final Long boardId) {
-        return boardRepository.findDetailById(boardId).orElseThrow(NotFoundException::new);
+        return boardRepository.findDetailById(boardId)
+                .orElseThrow(() -> new NotFoundException("게시글 조회 실패"));
     }
 
     /** 게시글 단건 조회 */
     public Board findById(final Long boardId) {
-        return boardRepository.findById(boardId).orElseThrow(NotFoundException::new);
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> new NotFoundException("게시글 조회 실패"));
     }
 
     public List<Board> findAll() {

--- a/src/main/java/io/wisoft/capstonedesign/domain/boardreply/application/BoardReplyService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/boardreply/application/BoardReplyService.java
@@ -83,14 +83,16 @@ public class BoardReplyService {
      * 게시글댓글 단건 조회
      */
     public BoardReply findById(final Long boardReplyId) {
-        return boardReplyRepository.findById(boardReplyId).orElseThrow(NotFoundException::new);
+        return boardReplyRepository.findById(boardReplyId)
+                .orElseThrow(() -> new NotFoundException("게시글 댓글 조회 실패"));
     }
 
     /**
      * 게시글댓글 단건 상세 조회
      */
     public BoardReply findDetailById(final Long boardReplyId) {
-        return boardReplyRepository.findDetailById(boardReplyId).orElseThrow(NotFoundException::new);
+        return boardReplyRepository.findDetailById(boardReplyId)
+                .orElseThrow(() -> new NotFoundException("게시글 댓글 조회 실패"));
     }
 
     /**

--- a/src/main/java/io/wisoft/capstonedesign/domain/businfo/application/BusInfoService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/businfo/application/BusInfoService.java
@@ -40,7 +40,8 @@ public class BusInfoService {
 
     /* 조회 로직 */
     public BusInfo findById(final Long busInfoId) {
-        return busInfoRepository.findById(busInfoId).orElseThrow(NotFoundException::new);
+        return busInfoRepository.findById(busInfoId)
+                .orElseThrow(() -> new NotFoundException("버스정보 조회 실패"));
     }
 
     public List<BusInfo> findAll() {

--- a/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/application/HealthInfoService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/healthinfo/application/HealthInfoService.java
@@ -57,11 +57,13 @@ public class HealthInfoService {
 
     /* 조회 로직 */
     public HealthInfo findById(final Long healthInfoId) {
-        return healthInfoRepository.findById(healthInfoId).orElseThrow(NotFoundException::new);
+        return healthInfoRepository.findById(healthInfoId)
+                .orElseThrow(() -> new NotFoundException("건강정보 조회 실패"));
     }
 
     public HealthInfo findDetailById(final Long healthInfoId) {
-        return healthInfoRepository.findDetailById(healthInfoId).orElseThrow(NotFoundException::new);
+        return healthInfoRepository.findDetailById(healthInfoId)
+                .orElseThrow(() -> new NotFoundException("건강정보 조회 실패"));
     }
 
     public List<HealthInfo> findAll() {

--- a/src/main/java/io/wisoft/capstonedesign/domain/hospital/application/HospitalService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/hospital/application/HospitalService.java
@@ -51,7 +51,8 @@ public class HospitalService {
      * 병원 단건 조회
      */
     public Hospital findById(final Long hospitalId) {
-        return hospitalRepository.findById(hospitalId).orElseThrow(NotFoundException::new);
+        return hospitalRepository.findById(hospitalId)
+                .orElseThrow(() -> new NotFoundException("병원 조회 실패"));
     }
 
     /* 병원 이름으로 조회 */

--- a/src/main/java/io/wisoft/capstonedesign/domain/member/application/MemberService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/member/application/MemberService.java
@@ -72,11 +72,13 @@ public class MemberService {
      * 회원 조회
      */
     public Member findById(final Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(NotFoundException::new);
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("회원 조회 실패"));
     }
 
     public Member findDetailById(final Long memberId) {
-        return memberRepository.findDetailById(memberId).orElseThrow(NotFoundException::new);
+        return memberRepository.findDetailById(memberId)
+                .orElseThrow(() -> new NotFoundException("회원 조회 실패"));
     }
 
     public List<Member> findAll() {

--- a/src/main/java/io/wisoft/capstonedesign/domain/payment/web/RefundController.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/payment/web/RefundController.java
@@ -63,11 +63,11 @@ public class RefundController {
     public ResponseEntity<String> refund(
             final HttpServletRequest httpServletRequest,
             @RequestBody final String merchantUid,
-            @PathVariable final Long appointmentId) {
+            @PathVariable final Long id) {
 
         final String token = extractor.extract(httpServletRequest, "Bearer");
 
-        final ResponseEntity<String> response = executePaymentCancel(token, merchantUid, appointmentId);
+        final ResponseEntity<String> response = executePaymentCancel(token, merchantUid, id);
 
         return response;
     }

--- a/src/main/java/io/wisoft/capstonedesign/domain/pick/application/PickService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/pick/application/PickService.java
@@ -46,11 +46,13 @@ public class PickService {
 
     /* 조회 로직 */
     public Pick findById(final Long pickId) {
-        return pickRepository.findById(pickId).orElseThrow(NotFoundException::new);
+        return pickRepository.findById(pickId)
+                .orElseThrow(() -> new NotFoundException("찜하기 조회 실패"));
     }
 
     /** 상세조회 */
     public Pick findDetailById(final Long pickId) {
-        return pickRepository.findDetailById(pickId).orElseThrow(NotFoundException::new);
+        return pickRepository.findDetailById(pickId)
+                .orElseThrow(() -> new NotFoundException("찜하기 조회 실패"));
     }
 }

--- a/src/main/java/io/wisoft/capstonedesign/domain/review/application/ReviewService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/review/application/ReviewService.java
@@ -97,14 +97,16 @@ public class ReviewService {
 
     /* 조회 로직 */
     public Review findById(final Long reviewId) {
-        return reviewRepository.findById(reviewId).orElseThrow(NotFoundException::new);
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new NotFoundException("리뷰 조회 실패"));
     }
 
     public List<Review> findAll() { return reviewRepository.findAll(); }
 
     /** 상세 조회 */
     public Review findDetailById(final Long reviewId) {
-        return reviewRepository.findDetailById(reviewId).orElseThrow(NotFoundException::new);
+        return reviewRepository.findDetailById(reviewId)
+                .orElseThrow(() -> new NotFoundException("리뷰 조회 실패"));
     }
 
     /** 리뷰 목록 페이징 조회 */

--- a/src/main/java/io/wisoft/capstonedesign/domain/reviewreply/application/ReviewReplyService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/reviewreply/application/ReviewReplyService.java
@@ -85,14 +85,16 @@ public class ReviewReplyService {
      * 리뷰댓글 단건조회
      */
     public ReviewReply findById(final Long reviewReplyId) {
-        return reviewReplyRepository.findById(reviewReplyId).orElseThrow(NotFoundException::new);
+        return reviewReplyRepository.findById(reviewReplyId)
+                .orElseThrow(() -> new NotFoundException("리뷰 댓글 조회 실패"));
     }
 
     /**
      * 리뷰댓글 단건 상세조회
      */
     public ReviewReply findDetailById(final Long reviewReplyId) {
-        return reviewReplyRepository.findDetailById(reviewReplyId).orElseThrow(NotFoundException::new);
+        return reviewReplyRepository.findDetailById(reviewReplyId)
+                .orElseThrow(() -> new NotFoundException("리뷰 댓글 조회 실패"));
     }
 
 

--- a/src/main/java/io/wisoft/capstonedesign/domain/staff/application/StaffMyPageService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/staff/application/StaffMyPageService.java
@@ -24,7 +24,7 @@ public class StaffMyPageService {
     public List<Review> findReviewByStaffHospitalName(final Long staffId) {
 
         final Staff staff = staffMyPageRepository.findById(staffId)
-                .orElseThrow(NotFoundException::new);
+                .orElseThrow(() -> new NotFoundException("의료진 조회 실패"));
 
         final String hospitalName = staff.getHospital().getName();
         return staffMyPageRepository.findReviewListByStaffHospitalName(hospitalName);

--- a/src/main/java/io/wisoft/capstonedesign/domain/staff/application/StaffService.java
+++ b/src/main/java/io/wisoft/capstonedesign/domain/staff/application/StaffService.java
@@ -73,11 +73,13 @@ public class StaffService {
      * 상세 조회
      */
     public Staff findDetailById(final Long staffId) {
-        return staffRepository.findDetailById(staffId).orElseThrow(NotFoundException::new);
+        return staffRepository.findDetailById(staffId)
+                .orElseThrow(() -> new NotFoundException("의료진 조회 실패"));
     }
 
     public Staff findById(final Long staffId) {
-        return staffRepository.findById(staffId).orElseThrow(NotFoundException::new);
+        return staffRepository.findById(staffId)
+                .orElseThrow(() -> new NotFoundException("의료진 조회 실패"));
     }
 
     public List<Staff> findAll() {

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorCode.java
@@ -3,6 +3,9 @@ package io.wisoft.capstonedesign.global.exception;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -10,37 +13,37 @@ public enum ErrorCode {
 
     //COMMON
     //@Builder 사용으로 인한 Assert 검증시 발생
-    ASSERT_INVALID_INPUT(400, "Common-Builder-400", "Builder가 요구하는 필수 파라미터가 요구되지 않았습니다."),
-    NOT_FOUND(404, "Common-NotFound-404", "해당 엔티티를 찾을 수 없습니다."),
-    TIME_OUT(500, "Common-TimeOut-500", "Timeout 발생"),
+    ASSERT_INVALID_INPUT(BAD_REQUEST, "Common-Builder-400", "Builder가 요구하는 필수 파라미터가 요구되지 않았습니다."),
+    NOT_FOUND(BAD_REQUEST, "Common-NotFound-404", "해당 엔티티를 찾을 수 없습니다."),
+    TIME_OUT(REQUEST_TIMEOUT, "Common-TimeOut-408", "Timeout 발생"),
 
 
     //DUPLICATE
-    DUPLICATE_EMAIL(400, "Duplicate-Mail-400", "Email is Duplicated"),
-    DUPLICATE_HOSPITAL(400, "Duplicate-Hospital-400", "HospitalName is Duplicated"),
+    DUPLICATE_EMAIL(BAD_REQUEST, "Duplicate-Mail-400", "Email is Duplicated"),
+    DUPLICATE_HOSPITAL(BAD_REQUEST, "Duplicate-Hospital-400", "HospitalName is Duplicated"),
 
 
     //ILLEGAL
-    ILLEGAL_HOSPITAL_DEPT(400, "Illegal-Dept-400", "HospitalDept is invalid"),
-    ILLEGAL_AREA(400, "Illegal-Area-400", "Area is invalid"),
-    ILLEGAL_DATE(400, "Illegal-Date-400", "Date is invalid"),
-    ILLEGAL_PASSWORD(400, "Illegal-Password-400", "Password is not match"),
-    ILLEGAL_CODE(400, "Illegal-Code-400", "CertificationCode is not match"),
-    ILLEGAL_PARAM(400, "Illegal-Param-400", "Parameter is empty"),
-    ILLEGAL_STATE(400, "Illegal-State-400", "State is something wrong"),
-    ILLEGAL_STAR_POINT(400, "Illegal-StarPoint-400", "StarPoint between 1 and 5"),
-    INVALID_TOKEN(403, "Illegal-Invalid-Token-401", "Token is invalid"),
-    NOT_EXIST_TOKEN(401, "Illegal-Not-Exist-Token-401", "Token is not exist"),
-    EXPIRED_TOKEN(401, "Illegal-Expired-Token-401", "Token is expired"),
-    ALREADY_LOGOUT_TOKEN(403, "Token-403", "Already logout token"),
-    JWT_EXCEPTION(400, "Token-400", "JWT is invalid");
+    ILLEGAL_HOSPITAL_DEPT(BAD_REQUEST, "Illegal-Dept-400", "HospitalDept is invalid"),
+    ILLEGAL_AREA(BAD_REQUEST, "Illegal-Area-400", "Area is invalid"),
+    ILLEGAL_DATE(BAD_REQUEST, "Illegal-Date-400", "Date is invalid"),
+    ILLEGAL_PASSWORD(BAD_REQUEST, "Illegal-Password-400", "Password is not match"),
+    ILLEGAL_CODE(BAD_REQUEST, "Illegal-Code-400", "CertificationCode is not match"),
+    ILLEGAL_PARAM(BAD_REQUEST, "Illegal-Param-400", "Parameter is empty"),
+    ILLEGAL_STATE(BAD_REQUEST, "Illegal-State-400", "State is something wrong"),
+    ILLEGAL_STAR_POINT(BAD_REQUEST, "Illegal-StarPoint-400", "StarPoint between 1 and 5"),
+    INVALID_TOKEN(FORBIDDEN, "Illegal-Invalid-Token-401", "Token is invalid"),
+    NOT_EXIST_TOKEN(UNAUTHORIZED, "Illegal-Not-Exist-Token-401", "Token is not exist"),
+    EXPIRED_TOKEN(UNAUTHORIZED, "Illegal-Expired-Token-401", "Token is expired"),
+    ALREADY_LOGOUT_TOKEN(FORBIDDEN, "Token-403", "Already logout token"),
+    JWT_EXCEPTION(UNAUTHORIZED, "Token-400", "JWT is invalid");
 
 
-    private int httpStatusCode;
+    private HttpStatus httpStatusCode;
     private String errorCode;
     private String message;
 
-    ErrorCode(final int httpStatusCode, final String errorCode, final String message) {
+    ErrorCode(final HttpStatus httpStatusCode, final String errorCode, final String message) {
         this.httpStatusCode = httpStatusCode;
         this.errorCode = errorCode;
         this.message = message;

--- a/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorResponse.java
+++ b/src/main/java/io/wisoft/capstonedesign/global/exception/ErrorResponse.java
@@ -1,11 +1,12 @@
 package io.wisoft.capstonedesign.global.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class ErrorResponse {
 
-    private final int httpStatusCode;
+    private final HttpStatus httpStatusCode;
     private final String errorCode;
     private final String message;
 

--- a/src/test/java/io/wisoft/capstonedesign/domain/payment/persistence/PaymentEntityTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/payment/persistence/PaymentEntityTest.java
@@ -1,0 +1,50 @@
+package io.wisoft.capstonedesign.domain.payment.persistence;
+
+import io.wisoft.capstonedesign.global.enumeration.status.PayStatus;
+import org.assertj.core.api.Assertions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentEntityTest {
+
+    @Test
+    public void refund() throws Exception {
+        //given -- 조건
+        final PaymentEntity payment = getPaymentEntity();
+
+        //when -- 동작
+        payment.refund();
+        
+        //then -- 검증
+        Assertions.assertThat(payment.getPayStatus()).isEqualTo(PayStatus.REFUND);
+    }
+
+    @NotNull
+    private static PaymentEntity getPaymentEntity() {
+        final PaymentEntity payment = PaymentEntity.createPaymentEntity(
+                "pg",
+                "paymentMethod",
+                "paymentName",
+                "buyerEmail",
+                "buyerName"
+        );
+        return payment;
+    }
+
+    @Test
+    public void validateParam_error() throws Exception {
+
+        assertThrows(IllegalArgumentException.class, () -> {
+
+            final PaymentEntity payment = PaymentEntity.createPaymentEntity(
+                    "",
+                    null,
+                    "paymentName",
+                    "buyerEmail",
+                    "buyerName"
+            );
+        });
+    }
+}

--- a/src/test/java/io/wisoft/capstonedesign/domain/payment/web/RefundControllerTest.java
+++ b/src/test/java/io/wisoft/capstonedesign/domain/payment/web/RefundControllerTest.java
@@ -1,0 +1,84 @@
+package io.wisoft.capstonedesign.domain.payment.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.wisoft.capstonedesign.domain.appointment.persistence.Appointment;
+import io.wisoft.capstonedesign.domain.appointment.persistence.AppointmentRepository;
+import io.wisoft.capstonedesign.global.enumeration.status.PayStatus;
+import io.wisoft.capstonedesign.setting.common.ApiTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+class RefundControllerTest extends ApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AppointmentRepository appointmentRepository;
+
+    @Test
+    public void getToken_success() throws Exception {
+
+        final var response = getToken();
+
+        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+
+    @Test
+    public void refund_success() throws Exception {
+
+        //given -- 조건
+        final Long appointmentId = 1L;
+        final Map<String, String> map = new HashMap<>();
+        map.put("merchantUid", "1");
+
+        final String jsonBody = objectMapper.writeValueAsString(map);
+
+        //when -- 동작
+        mockMvc.perform(post("/payment/cancel/{id}", appointmentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody)
+                )
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.log())
+                .andDo(print());
+
+        //then -- 검증
+        final Appointment find = appointmentRepository.findById(appointmentId).orElseThrow();
+        Assertions.assertThat(find.getPayStatus()).isEqualTo(PayStatus.REFUND);
+    }
+
+
+    private ExtractableResponse<Response> getToken() {
+        final var response = RestAssured
+                .given()
+                .log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/payment/token")
+                .then()
+                .log().all().extract();
+        return response;
+    }
+}


### PR DESCRIPTION
## What is this PR? 📍
결제 테스트의 경우는 프론트 서버에서 호출한 결제창으로부터 결제를 완료한 후의 응답이 필요하므로 테스트하기가 어렵습니다.
따라서 우선 결제취소(환불) 관련 테스트를 작성하였습니다.

<br/>

## Changes 🔍
지난 코드리뷰 내용들을 반영하였습니다.
1. int형으로 관리하던 httpStatusCode 대신 HttpStatus enum 사용으로 전환
2. NotFoundException 발생시 메시지를 통해 어느 엔티티의 조회 실패인지 알 수 있도록 변경하였습니다.


<br/>
 
## Todo 🗓️

<br/>