### PR TITLE
chore : Jacoco 의존성 추가 및 테스트 커버리지 측정(#175)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.2'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'jacoco'
 }
 
 group = 'io.wisoft'
@@ -84,4 +85,18 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+jacocoTestReport {
+    dependsOn test
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "**/global/**",
+                    "**/dto",
+                    "**/a_test_redis"
+            ])
+        }))
+    }
 }


### PR DESCRIPTION
## What is this PR? 📍
테스트 커버리지 측정도구인 Jacoco 의존성을 추가하고, 테스트 커버리지를 측정합니다.

여러 도구 중 Jacoco를 택한 이유는 [해당 관련 이슈](https://github.com/HBNU-Avocado/Avocado-backend/issues/175)에서 확인하실 수 있습니다.

현재 테스트 커버리지 72%를 달성하여, 80%를 채우기 위해 앞으로도 꾸준히 테스트코드를 작성할 예정입니다.

![스크린샷 2023-06-24 오후 5 24 37](https://github.com/HBNU-Avocado/Avocado-backend/assets/95692663/8e9c22b0-e7c8-4395-9b0e-9a444db4325e)


<br/>

## Changes 🔍

Jacoco 의존성 추가

<br/>
 
## Todo 🗓️

<br/>